### PR TITLE
Disable Beta TestFlight Deployment

### DIFF
--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -19,13 +19,13 @@ jobs:
     name: Build and Test
     uses: ./.github/workflows/build-and-test.yml
     secrets: inherit
-  iosapptestflightdeployment:
-    name: iOS App TestFlight Deployment
-    needs: buildandtest
-    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-    secrets: inherit
-    with:
-      artifactname: LLMonFHIR.xcresult
-      runsonlabels: '["macOS", "self-hosted"]'
-      fastlanelane: beta
-      setupsigning: true
+#   iosapptestflightdeployment:
+#     name: iOS App TestFlight Deployment
+#     needs: buildandtest
+#     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+#     secrets: inherit
+#     with:
+#       artifactname: LLMonFHIR.xcresult
+#       runsonlabels: '["macOS", "self-hosted"]'
+#       fastlanelane: beta
+#       setupsigning: true


### PR DESCRIPTION
# Disable Beta TestFlight Deployment

## :bulb: Proposed solution
- Disables the beta TestFlight deployment as long as the repo is private.


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

