### PR TITLE
Add Pull to Refresh and Beta Deployment

### DIFF
--- a/.github/workflows/beta-deployment.yml
+++ b/.github/workflows/beta-deployment.yml
@@ -19,13 +19,13 @@ jobs:
     name: Build and Test
     uses: ./.github/workflows/build-and-test.yml
     secrets: inherit
-#   iosapptestflightdeployment:
-#     name: iOS App TestFlight Deployment
-#     needs: buildandtest
-#     uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
-#     secrets: inherit
-#     with:
-#       artifactname: LLMonFHIR.xcresult
-#       runsonlabels: '["macOS", "self-hosted"]'
-#       fastlanelane: beta
-#       setupsigning: true
+  iosapptestflightdeployment:
+    name: iOS App TestFlight Deployment
+    needs: buildandtest
+    uses: StanfordBDHG/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
+    secrets: inherit
+    with:
+      artifactname: LLMonFHIR.xcresult
+      runsonlabels: '["macOS", "self-hosted"]'
+      fastlanelane: beta
+      setupsigning: true

--- a/LLMonFHIR/FHIR Display/FHIRResourcesView.swift
+++ b/LLMonFHIR/FHIR Display/FHIRResourcesView.swift
@@ -6,11 +6,13 @@
 // SPDX-License-Identifier: MIT
 //
 
+import SpeziHealthKit
 import SpeziOpenAI
 import SwiftUI
 
 
 struct FHIRResourcesView: View {
+    @EnvironmentObject var healthKitModule: HealthKit<FHIR>
     @EnvironmentObject var fhirStandard: FHIR
     @State var resources: [String: [VersionedResource]] = [:]
     @State var showSettings = false
@@ -49,6 +51,9 @@ struct FHIRResourcesView: View {
                     OpenAIAPIKeyOnboardingStep<FHIR> {
                         showSettings.toggle()
                     }
+                }
+                .refreshable {
+                    await healthKitModule.triggerDataSourceCollection()
                 }
                 .navigationTitle("FHIR_RESOURCES_TITLE")
         }

--- a/LLMonFHIR/LLMonFHIRDelegate.swift
+++ b/LLMonFHIR/LLMonFHIRDelegate.swift
@@ -27,21 +27,21 @@ class LLMonFHIRDelegate: SpeziAppDelegate {
     
     
     private var healthKit: HealthKit<FHIR> {
-        HealthKit {
-            CollectSamples(
-                [
-                    HKClinicalType(.allergyRecord),
-                    HKClinicalType(.clinicalNoteRecord),
-                    HKClinicalType(.conditionRecord),
-                    HKClinicalType(.coverageRecord),
-                    HKClinicalType(.immunizationRecord),
-                    HKClinicalType(.labResultRecord),
-                    HKClinicalType(.medicationRecord),
-                    HKClinicalType(.procedureRecord),
-                    HKClinicalType(.vitalSignRecord)
-                ],
-                deliverySetting: .anchorQuery(saveAnchor: false)
-            )
+        let hkSampleTypes: Set<HKClinicalType> = [
+            HKClinicalType(.allergyRecord),
+            HKClinicalType(.clinicalNoteRecord),
+            HKClinicalType(.conditionRecord),
+            HKClinicalType(.coverageRecord),
+            HKClinicalType(.immunizationRecord),
+            HKClinicalType(.labResultRecord),
+            HKClinicalType(.medicationRecord),
+            HKClinicalType(.procedureRecord),
+            HKClinicalType(.vitalSignRecord)
+        ]
+        
+        return HealthKit<FHIR> {
+            CollectSamples(hkSampleTypes, deliverySetting: .anchorQuery(saveAnchor: false))
+            CollectSamples(hkSampleTypes, deliverySetting: .manual(safeAnchor: false))
         } adapter: {
             HealthKitToFHIRAdapter()
         }

--- a/LLMonFHIR/Resources/Localizable.strings
+++ b/LLMonFHIR/Resources/Localizable.strings
@@ -58,6 +58,8 @@
 "FHIR_RESOURCES_VIEW_NO_RESOURCES" = "
 No health records are available.
 
+Pull to refresh to manually reload your health records.
+
 Please follow the instructions to connect to retrieve your health records from your provider: [Apple Support - View health records on your iPhone or iPod touch](https://support.apple.com/en-us/HT208680).
 
 You can find a list of supported institutions at [Apple Support - Institutions that support health records on iPhone and iPod touch](https://platform.openai.com/account/api-keys).
@@ -67,6 +69,7 @@ If you can see your health records in the Apple Health app, please ensure that L
 "FHIR_RESOURCES_VIEW_INSTRUCTION" = "Welcome to LLM on FHIR
 
 You can inspect the different resources in your Apple Health app by tapping on a resource. You can ask follow-up questions in the chat view in each resource.
+
 You can load a title and summary for each resource using a long press on a resource.
 ";
 


### PR DESCRIPTION
# Add Pull to Refresh and Beta Deployment

## :recycle: Current situation & Problem
- The application does not provide a mechanism to manually reload the data.

## :bulb: Proposed solution
- Adds a pull to refresh gesture to reload health records
- Fixes the application beta deployment


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

