### PR TITLE
Improve List Overview, Add Summary to Detail View, Add Settings Screen, and Modify Prompt Settings

### DIFF
--- a/LLMonFHIR.xcodeproj/project.pbxproj
+++ b/LLMonFHIR.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F0F90BA2A1E6556006D7E03 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0F90B92A1E6556006D7E03 /* SettingsView.swift */; };
+		2F0F90BC2A1E6B19006D7E03 /* PromptSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0F90BB2A1E6B19006D7E03 /* PromptSettingsView.swift */; };
+		2F0F90BE2A1E702B006D7E03 /* Prompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0F90BD2A1E702B006D7E03 /* Prompt.swift */; };
 		2F49B7762980407C00BCB272 /* Spezi in Frameworks */ = {isa = PBXBuildFile; productRef = 2F49B7752980407B00BCB272 /* Spezi */; };
 		2F4E237E2989A2FE0013F3D9 /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */; };
 		2F4E23832989D51F0013F3D9 /* LLMonFHIRTestingSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E23822989D51F0013F3D9 /* LLMonFHIRTestingSetup.swift */; };
@@ -23,7 +26,7 @@
 		2FD8E82C2A1AADDA00357F4E /* ModelsR4 in Frameworks */ = {isa = PBXBuildFile; productRef = 2FD8E82B2A1AADDA00357F4E /* ModelsR4 */; };
 		2FD8E82E2A1AAFC300357F4E /* HealthKitToFHIRAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD8E82D2A1AAFC300357F4E /* HealthKitToFHIRAdapter.swift */; };
 		2FD8E8312A1AB00D00357F4E /* HealthKitOnFHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 2FD8E8302A1AB00D00357F4E /* HealthKitOnFHIR */; };
-		2FD8E8332A1AB68E00357F4E /* VersionedResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD8E8322A1AB68E00357F4E /* VersionedResource.swift */; };
+		2FD8E8332A1AB68E00357F4E /* FHIRResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD8E8322A1AB68E00357F4E /* FHIRResource.swift */; };
 		2FD8E83B2A1AD10300357F4E /* FHIRResourcesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD8E83A2A1AD10300357F4E /* FHIRResourcesView.swift */; };
 		2FD8E83D2A1AE24F00357F4E /* InspectResourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FD8E83C2A1AE24F00357F4E /* InspectResourceView.swift */; };
 		2FD8E8402A1AE3F200357F4E /* SpeziViews in Frameworks */ = {isa = PBXBuildFile; productRef = 2FD8E83F2A1AE3F200357F4E /* SpeziViews */; };
@@ -64,6 +67,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2F0F90B92A1E6556006D7E03 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		2F0F90BB2A1E6B19006D7E03 /* PromptSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptSettingsView.swift; sourceTree = "<group>"; };
+		2F0F90BD2A1E702B006D7E03 /* Prompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prompt.swift; sourceTree = "<group>"; };
 		2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
 		2F4E23822989D51F0013F3D9 /* LLMonFHIRTestingSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LLMonFHIRTestingSetup.swift; sourceTree = "<group>"; };
 		2F55FC522A1AE8750051DF48 /* FHIRResourceInterpreter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FHIRResourceInterpreter.swift; sourceTree = "<group>"; };
@@ -77,7 +83,7 @@
 		2FC975A72978F11A00BA99FE /* Home.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Home.swift; sourceTree = "<group>"; };
 		2FD8E8262A1AAD9B00357F4E /* FHIR.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FHIR.swift; sourceTree = "<group>"; };
 		2FD8E82D2A1AAFC300357F4E /* HealthKitToFHIRAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitToFHIRAdapter.swift; sourceTree = "<group>"; };
-		2FD8E8322A1AB68E00357F4E /* VersionedResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionedResource.swift; sourceTree = "<group>"; };
+		2FD8E8322A1AB68E00357F4E /* FHIRResource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FHIRResource.swift; sourceTree = "<group>"; };
 		2FD8E83A2A1AD10300357F4E /* FHIRResourcesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FHIRResourcesView.swift; sourceTree = "<group>"; };
 		2FD8E83C2A1AE24F00357F4E /* InspectResourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InspectResourceView.swift; sourceTree = "<group>"; };
 		2FE5DC3029EDD7CA004B9AB4 /* HealthKitPermissions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HealthKitPermissions.swift; sourceTree = "<group>"; };
@@ -134,6 +140,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2F0F90B82A1E6542006D7E03 /* Settings */ = {
+			isa = PBXGroup;
+			children = (
+				2F0F90B92A1E6556006D7E03 /* SettingsView.swift */,
+				2F0F90BB2A1E6B19006D7E03 /* PromptSettingsView.swift */,
+				2F0F90BD2A1E702B006D7E03 /* Prompt.swift */,
+			);
+			path = Settings;
+			sourceTree = "<group>";
+		};
 		2FC9759D2978E30800BA99FE /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -147,7 +163,7 @@
 			isa = PBXGroup;
 			children = (
 				2FD8E8262A1AAD9B00357F4E /* FHIR.swift */,
-				2FD8E8322A1AB68E00357F4E /* VersionedResource.swift */,
+				2FD8E8322A1AB68E00357F4E /* FHIRResource.swift */,
 				2FD8E82D2A1AAFC300357F4E /* HealthKitToFHIRAdapter.swift */,
 			);
 			path = "FHIR Standard";
@@ -238,6 +254,7 @@
 				2FE5DC2829EDD398004B9AB4 /* Onboarding */,
 				2FD8E81D2A1AAC6900357F4E /* FHIR Standard */,
 				2FD8E8392A1AD0E900357F4E /* FHIR Display */,
+				2F0F90B82A1E6542006D7E03 /* Settings */,
 				2FE5DC3C29EDD7DA004B9AB4 /* SharedContext */,
 				2FE5DC3D29EDD7E4004B9AB4 /* Helper */,
 				2FE5DC2D29EDD792004B9AB4 /* Resources */,
@@ -452,11 +469,14 @@
 				2F61A3302A1B51BF000A7796 /* FHIRResourceSummary.swift in Sources */,
 				2FE5DC3A29EDD7CA004B9AB4 /* Welcome.swift in Sources */,
 				2FE5DC3829EDD7CA004B9AB4 /* Disclaimer.swift in Sources */,
-				2FD8E8332A1AB68E00357F4E /* VersionedResource.swift in Sources */,
+				2FD8E8332A1AB68E00357F4E /* FHIRResource.swift in Sources */,
+				2F0F90BC2A1E6B19006D7E03 /* PromptSettingsView.swift in Sources */,
 				2F61A3322A1B560B000A7796 /* ResourceSummaryView.swift in Sources */,
 				2FD8E83D2A1AE24F00357F4E /* InspectResourceView.swift in Sources */,
+				2F0F90BA2A1E6556006D7E03 /* SettingsView.swift in Sources */,
 				2FD8E83B2A1AD10300357F4E /* FHIRResourcesView.swift in Sources */,
 				2FD8E82E2A1AAFC300357F4E /* HealthKitToFHIRAdapter.swift in Sources */,
+				2F0F90BE2A1E702B006D7E03 /* Prompt.swift in Sources */,
 				2FE5DC4529EDD7F2004B9AB4 /* Binding+Negate.swift in Sources */,
 				2FC975A82978F11A00BA99FE /* Home.swift in Sources */,
 				2FE5DC3729EDD7CA004B9AB4 /* OnboardingFlow.swift in Sources */,

--- a/LLMonFHIR/FHIR Display/FHIRResourceInterpreter.swift
+++ b/LLMonFHIR/FHIR Display/FHIRResourceInterpreter.swift
@@ -19,7 +19,7 @@ private enum FHIRResourceInterpreterConstants {
 
 
 class FHIRResourceInterpreter<ComponentStandard: Standard>: DefaultInitializable, Component, ObservableObject, ObservableObjectProvider {
-    typealias Interpretations = [VersionedResource.ID: String]
+    typealias Interpretations = [FHIRResource.ID: String]
     
     
     @Dependency private var localStorage: LocalStorage
@@ -54,7 +54,7 @@ class FHIRResourceInterpreter<ComponentStandard: Standard>: DefaultInitializable
     }
     
     
-    func interpret(resource: VersionedResource) async throws {
+    func interpret(resource: FHIRResource) async throws {
         let chatStreamResults = try await openAIComponent.queryAPI(withChat: [systemPrompt(forResource: resource)])
         
         self.interpretations[resource.id] = ""
@@ -67,7 +67,7 @@ class FHIRResourceInterpreter<ComponentStandard: Standard>: DefaultInitializable
         }
     }
     
-    func chat(forResource resource: VersionedResource) -> [Chat] {
+    func chat(forResource resource: FHIRResource) -> [Chat] {
         var chat = [systemPrompt(forResource: resource)]
         if let interpretation = interpretations[resource.id] {
             chat.append(Chat(role: .assistant, content: interpretation))
@@ -75,10 +75,10 @@ class FHIRResourceInterpreter<ComponentStandard: Standard>: DefaultInitializable
         return chat
     }
     
-    private func systemPrompt(forResource resource: VersionedResource) -> Chat {
+    private func systemPrompt(forResource resource: FHIRResource) -> Chat {
         Chat(
             role: .system,
-            content: String(localized: "FHIR_RESOURCE_INTERPRETATION_PROMPT \(resource.jsonDescription)")
+            content: Prompt.interpretation.prompt.replacingOccurrences(of: Prompt.promptPlaceholder, with: resource.compactJSONDescription)
         )
     }
 }

--- a/LLMonFHIR/FHIR Display/FHIRResourceSummary.swift
+++ b/LLMonFHIR/FHIR Display/FHIRResourceSummary.swift
@@ -19,33 +19,30 @@ private enum FHIRResourceSummaryConstants {
 
 
 class FHIRResourceSummary<ComponentStandard: Standard>: DefaultInitializable, Component, ObservableObject, ObservableObjectProvider {
-    typealias Summaries = [VersionedResource.ID: FHIRResourceSummary]
+    typealias Summaries = [FHIRResource.ID: FHIRResourceSummary]
     
     
     struct FHIRResourceSummary: LosslessStringConvertible, Codable {
         init?(_ description: String) {
             let lines = description.split(whereSeparator: \.isNewline)
             
-            guard lines.count == 2, let title = lines.first, let summary = lines.last else {
+            guard lines.count == 1, let summary = lines.first else {
                 return nil
             }
             
-            self.title = String(title)
             self.summary = String(summary)
         }
         
-        init(title: String, summary: String) {
-            self.title = title
+        init(summary: String) {
             self.summary = summary
         }
         
         
-        let title: String
         let summary: String
         
         
         var description: String {
-            "\(title)\n\(summary)"
+            summary
         }
     }
     
@@ -81,8 +78,7 @@ class FHIRResourceSummary<ComponentStandard: Standard>: DefaultInitializable, Co
         self.summaries = cachedSummaries
     }
     
-    
-    func summarize(resource: VersionedResource) async throws {
+    func summarize(resource: FHIRResource) async throws {
         guard summaries[resource.id] == nil else {
             return
         }
@@ -101,10 +97,10 @@ class FHIRResourceSummary<ComponentStandard: Standard>: DefaultInitializable, Co
     }
     
     
-    private func systemPrompt(forResource resource: VersionedResource) -> Chat {
+    private func systemPrompt(forResource resource: FHIRResource) -> Chat {
         Chat(
             role: .system,
-            content: String(localized: "FHIR_RESOURCE_SUMMARY_PROMPT \(resource.jsonDescription)")
+            content: Prompt.summary.prompt.replacingOccurrences(of: Prompt.promptPlaceholder, with: resource.compactJSONDescription)
         )
     }
 }

--- a/LLMonFHIR/FHIR Display/InspectResourceChat.swift
+++ b/LLMonFHIR/FHIR Display/InspectResourceChat.swift
@@ -18,13 +18,13 @@ struct InspectResourceChat: View {
     @State var chat: [Chat]
     @State var gettingAnswer = false
     
-    let resource: VersionedResource
+    let resource: FHIRResource
     
     
     var body: some View {
         NavigationStack {
             ChatView($chat, disableInput: $gettingAnswer)
-                .navigationTitle(fhirResourceSummary.summaries[resource.id]?.title ?? resource.compactDescription)
+                .navigationTitle(resource.displayName)
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
                         Button("FHIR_RESOURCES_CHAT_CANCEL") {

--- a/LLMonFHIR/FHIR Display/ResourceSummaryView.swift
+++ b/LLMonFHIR/FHIR Display/ResourceSummaryView.swift
@@ -14,29 +14,25 @@ struct ResourceSummaryView: View {
     
     @State var loading = false
     
-    let resource: VersionedResource
+    let resource: FHIRResource
     
     
     var body: some View {
         ZStack {
             if let summary = fhirResourceSummary.summaries[resource.id] {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text(summary.title)
+                    Text(resource.displayName)
                     Text(summary.summary)
                         .font(.caption)
                 }
                     .multilineTextAlignment(.leading)
             } else {
                 VStack(alignment: .leading, spacing: 4) {
-                    Text("FHIR_RESOURCES_SUMMARY_ID_TITLE \(resource.id ?? "-")")
+                    Text(resource.displayName)
                     if loading {
                         ProgressView()
                             .progressViewStyle(.circular)
                             .padding(.vertical, 6)
-                    } else {
-                        Text("FHIR_RESOURCES_SUMMARY_INSTRUCTION")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
                     }
                 }
                     .contextMenu {

--- a/LLMonFHIR/FHIR Standard/FHIR.swift
+++ b/LLMonFHIR/FHIR Standard/FHIR.swift
@@ -13,7 +13,7 @@ import XCTRuntimeAssertions
 
 
 actor FHIR: Standard, ObservableObject, ObservableObjectProvider {
-    typealias BaseType = VersionedResource
+    typealias BaseType = FHIRResource
     typealias RemovalContext = FHIRRemovalContext
     
     
@@ -29,7 +29,7 @@ actor FHIR: Standard, ObservableObject, ObservableObjectProvider {
     }
     
     
-    var resources: [VersionedResource.ID: VersionedResource] = [:] {
+    var resources: [FHIRResource.ID: FHIRResource] = [:] {
         didSet {
             _Concurrency.Task { @MainActor in
                 objectWillChange.send()

--- a/LLMonFHIR/FHIR Standard/HealthKitToFHIRAdapter.swift
+++ b/LLMonFHIR/FHIR Standard/HealthKitToFHIRAdapter.swift
@@ -42,7 +42,10 @@ actor HealthKitToFHIRAdapter: SingleValueAdapter {
             
             let decoder = JSONDecoder()
             let resourceProxy = try decoder.decode(ModelsDSTU2.ResourceProxy.self, from: fhirResource.data)
-            return .dstu2(resourceProxy.get())
+            return FHIRResource(
+                versionedResouce: .dstu2(resourceProxy.get()),
+                displayName: clinicalResource.displayName
+            )
         case let electrocardiogram as HKElectrocardiogram:
             guard let hkHealthStore else {
                 fallthrough
@@ -55,9 +58,16 @@ actor HealthKitToFHIRAdapter: SingleValueAdapter {
                 symptoms: symptoms,
                 voltageMeasurements: voltageMeasurements
             )
-            return .r4(resource)
+            return FHIRResource(
+                versionedResouce: .r4(resource),
+                displayName: String(localized: "FHIR_RESOURCES_SUMMARY_ID_TITLE \(resource.id?.value?.string ?? "-")")
+            )
         default:
-            return try .r4(element.resource.get())
+            let resource = try element.resource.get()
+            return FHIRResource(
+                versionedResouce: .r4(resource),
+                displayName: String(localized: "FHIR_RESOURCES_SUMMARY_ID_TITLE \(resource.id?.value?.string ?? "-")")
+            )
         }
     }
     

--- a/LLMonFHIR/Resources/Localizable.strings
+++ b/LLMonFHIR/Resources/Localizable.strings
@@ -70,12 +70,12 @@ You can inspect the different resources in your Apple Health app by tapping on a
 
 You can load a title and summary for each resource using a long press on a resource.
 ";
-"OPEN_AI_KEY_SAVE_ACTION" = "Save API Key";
 
 
 // MARK: FHIR Resource Summary
 "FHIR_RESOURCES_SUMMARY_ID_TITLE %@" = "Resource with id %@";
 "FHIR_RESOURCES_SUMMARY_INSTRUCTION" = "Long press the resource and select \"Load Resource Summary\" to let LLM on FHIR create a title and summary of this resource.";
+"FHIR_RESOURCES_SUMMARY_SECTION" = "Summary";
 "FHIR_RESOURCES_SUMMARY_BUTTON" = "Load Resource Summary";
 
 // MARK: FHIR Resource Interpretation
@@ -97,10 +97,9 @@ Your task is to interpret the following FHIR resource from the user's clinical r
 The following JSON representation defines the FHIR resource that you should interpret:
 %@
  
-Return a short title of the resource summarizing its purpose in less than 50 characters without including the word title.
-After the title, add a new line and provide a short one-sentence summary of the resource in less than 20 words.
-Do NOT respond with more content than the two lines containing the title and summary.
-Do NOT start the lines with 'Title:' or 'Summary:'. Directly provide the content without any additional structure.
+Provide a short one-sentence summary of the resource in less than 20 words.
+Do NOT respond with more content than the single line containing the summary.
+Directly provide the content without any additional structure.
 ";
 
 "FHIR_RESOURCE_INTERPRETATION_PROMPT %@" = "
@@ -117,3 +116,21 @@ The following JSON representation defines the FHIR resource that you should inte
 Immediately return an interpretation to the user, starting the conversation.
 Do not introduce yourself at the beginning, and start with your interpretation.
 ";
+
+
+// MARK: - Settings
+"SETTINGS_TITLE" = "Settings";
+
+"SETTINGS_OPENAI" = "Open AI Settings";
+"SETTINGS_OPENAI_KEY" = "Open AI API Key";
+"SETTINGS_OPENAI_MODEL" = "Open AI Model";
+
+"OPEN_AI_KEY_SAVE_ACTION" = "Save API Key";
+"OPEN_AI_MODEL_SAVE_ACTION" = "Save Model Selection";
+
+"SETTINGS_PROMPTS" = "Prompt Settings";
+"SETTINGS_PROMPTS_SUMMARY" = "Summary Prompt";
+"SETTINGS_PROMPTS_INTERPRETATION" = "Interpretation Prompt";
+"SETTINGS_PROMPT_DESCRITPTION %@" = "Customize the %@ prompt.";
+"SETTINGS_PROMPT_CAPTION %@" = "SPlace %@ at the position in the prompt where the FHIR resource should be inserted.";
+"SETTINGS_PROMPT_SAVE_BUTTON" = "Save Prompt";

--- a/LLMonFHIR/Settings/Prompt.swift
+++ b/LLMonFHIR/Settings/Prompt.swift
@@ -1,0 +1,48 @@
+//
+// This source file is part of the Stanford LLM on FHIR project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+enum Prompt: String {
+    /// The summary prompt
+    case summary = "prompt.summary"
+    /// The interpretation prompt
+    case interpretation = "prompt.interpretation"
+    
+    
+    static let promptPlaceholder = "%@"
+    
+    
+    var localizedDescription: String {
+        switch self {
+        case .summary:
+            return String(localized: "SETTINGS_PROMPTS_SUMMARY")
+        case .interpretation:
+            return String(localized: "SETTINGS_PROMPTS_INTERPRETATION")
+        }
+    }
+    
+    var defaultPrompt: String {
+        switch self {
+        case .summary:
+            return String(localized: "FHIR_RESOURCE_SUMMARY_PROMPT \("%@")")
+        case .interpretation:
+            return String(localized: "FHIR_RESOURCE_INTERPRETATION_PROMPT \("%@")")
+        }
+    }
+    
+    
+    var prompt: String {
+        UserDefaults.standard.string(forKey: rawValue) ?? defaultPrompt
+    }
+    
+    func save(prompt: String) {
+        UserDefaults.standard.set(prompt, forKey: rawValue)
+    }
+}

--- a/LLMonFHIR/Settings/PromptSettingsView.swift
+++ b/LLMonFHIR/Settings/PromptSettingsView.swift
@@ -1,0 +1,57 @@
+//
+// This source file is part of the Stanford LLM on FHIR project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+struct PromptSettingsView: View {
+    private let promptType: Prompt
+    @State private var prompt: String = ""
+    @Binding private var path: NavigationPath
+    
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Customize the \(promptType.localizedDescription.lowercased()) prompt.")
+                .multilineTextAlignment(.leading)
+            TextEditor(text: $prompt)
+                .fontDesign(.monospaced)
+            Text("Place \(Prompt.promptPlaceholder) at the position in the prompt where the FHIR resource should be inserted.")
+                .multilineTextAlignment(.leading)
+                .font(.caption)
+            Button(
+                action: {
+                    promptType.save(prompt: prompt)
+                    path.removeLast()
+                },
+                label: {
+                    Text("SETTINGS_PROMPT_SAVE_BUTTON")
+                        .frame(maxWidth: .infinity, minHeight: 40)
+                }
+            )
+            .buttonStyle(.borderedProminent)
+        }
+            .padding()
+            .navigationTitle(promptType.localizedDescription)
+    }
+    
+    
+    init(promptType: Prompt, path: Binding<NavigationPath>) {
+        self.promptType = promptType
+        self._prompt = State(initialValue: promptType.prompt)
+        self._path = path
+    }
+}
+
+struct PromptSettingsView_Previews: PreviewProvider {
+    @State private static var path = NavigationPath()
+    
+    static var previews: some View {
+        PromptSettingsView(promptType: .summary, path: $path)
+    }
+}

--- a/LLMonFHIR/Settings/SettingsView.swift
+++ b/LLMonFHIR/Settings/SettingsView.swift
@@ -1,0 +1,78 @@
+//
+// This source file is part of the Stanford LLM on FHIR project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziOpenAI
+import SwiftUI
+
+
+struct SettingsView: View {
+    private enum SettingsDestinations {
+        case openAIKey
+        case openAIModel
+        case promptSummary
+        case promptInterpretation
+    }
+    
+    @State private var path = NavigationPath()
+    @Environment(\.dismiss) private var dismiss
+
+    
+    var body: some View {
+        NavigationStack(path: $path) {
+            List {
+                Section("SETTINGS_OPENAI") {
+                    NavigationLink(value: SettingsDestinations.openAIKey) {
+                        Text("SETTINGS_OPENAI_KEY")
+                    }
+                    NavigationLink(value: SettingsDestinations.openAIModel) {
+                        Text("SETTINGS_OPENAI_MODEL")
+                    }
+                }
+                Section("SETTINGS_PROMPTS") {
+                    NavigationLink(value: SettingsDestinations.promptSummary) {
+                        Text("SETTINGS_PROMPTS_SUMMARY")
+                    }
+                    NavigationLink(value: SettingsDestinations.promptInterpretation) {
+                        Text("SETTINGS_PROMPTS_INTERPRETATION")
+                    }
+                }
+            }
+                .navigationTitle("SETTINGS_TITLE")
+                .navigationDestination(for: SettingsDestinations.self) { destination in
+                    navigationDesination(for: destination)
+                }
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("FHIR_RESOURCES_CHAT_CANCEL") {
+                            dismiss()
+                        }
+                    }
+                }
+        }
+    }
+    
+    
+    private func navigationDesination(for destination: SettingsDestinations) -> some View {
+        Group {
+            switch destination {
+            case .openAIKey:
+                OpenAIAPIKeyOnboardingStep<FHIR>(actionText: String(localized: "OPEN_AI_KEY_SAVE_ACTION")) {
+                    path.removeLast()
+                }
+            case .openAIModel:
+                OpenAIModelSelectionOnboardingStep<FHIR>(actionText: String(localized: "OPEN_AI_MODEL_SAVE_ACTION")) {
+                    path.removeLast()
+                }
+            case .promptSummary:
+                PromptSettingsView(promptType: .summary, path: $path)
+            case .promptInterpretation:
+                PromptSettingsView(promptType: .interpretation, path: $path)
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Improve List Overview, Add Summary to Detail View, Add Settings Screen, and Modify Prompt Settings

## :recycle: Current situation & Problem
- The list currently only describes the resources using their identifier
- There is no way to see the summary in the detail view
- The prompts are currently not transparent and easy to modify in the app

## :bulb: Proposed solution
- Improve List Overview
- Add Summary to Detail View
- Add Settings Screen
- Modify Prompt Settings


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

