### PR TITLE
Fix Crash Due to Actor Context

### DIFF
--- a/LLMonFHIR/FHIR Display/FHIRResourcesView.swift
+++ b/LLMonFHIR/FHIR Display/FHIRResourcesView.swift
@@ -105,8 +105,7 @@ struct FHIRResourcesView: View {
     
     private func loadFHIRResources() {
         Task { @MainActor in
-            let values = await fhirStandard.resources.values
-            let resources = Array(values)
+            let resources = await fhirStandard.resources
             self.resources = [:]
             for resource in resources {
                 var currentResources = self.resources[resource.resourceType, default: []]

--- a/LLMonFHIR/FHIR Standard/FHIR.swift
+++ b/LLMonFHIR/FHIR Standard/FHIR.swift
@@ -29,12 +29,16 @@ actor FHIR: Standard, ObservableObject, ObservableObjectProvider {
     }
     
     
-    var resources: [FHIRResource.ID: FHIRResource] = [:] {
+    private var _resources: [FHIRResource.ID: FHIRResource] = [:] {
         didSet {
             _Concurrency.Task { @MainActor in
                 objectWillChange.send()
             }
         }
+    }
+    
+    var resources: [FHIRResource] {
+        Array(_resources.values)
     }
     
     
@@ -46,12 +50,12 @@ actor FHIR: Standard, ObservableObject, ObservableObjectProvider {
                     guard let id = resource.id else {
                         continue
                     }
-                    resources[id] = resource
+                    _resources[id] = resource
                 case let .removal(removalContext):
                     guard let id = removalContext.id else {
                         continue
                     }
-                    resources[id] = nil
+                    _resources[id] = nil
                 }
             }
         }

--- a/LLMonFHIR/Resources/Localizable.strings
+++ b/LLMonFHIR/Resources/Localizable.strings
@@ -103,7 +103,7 @@ Directly provide the content without any additional structure.
 ";
 
 "FHIR_RESOURCE_INTERPRETATION_PROMPT %@" = "
-You are the LLM on FHIR applicatation.
+You are the LLM on FHIR application.
 Your task is to interpret the following FHIR resource from the user's clinical record.
 
 Interpret the resource by explaining its data relevant to the user's health.


### PR DESCRIPTION
# Fix Crash Due to Actor Context

## :recycle: Current situation & Problem
- We have gotten reports about several crashes when FHIR data is transformed from a dictionary to an array outside of the FHIR actor context. 

## :bulb: Proposed solution
- Moves the mapping inside the actor context.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

