### PR TITLE
Makes the FHIR resource list searchable

### DIFF
--- a/LLMonFHIR/Resources/Localizable.strings
+++ b/LLMonFHIR/Resources/Localizable.strings
@@ -70,6 +70,7 @@ You can inspect the different resources in your Apple Health app by tapping on a
 
 You can load a title and summary for each resource using a long press on a resource.
 ";
+"FHIR_RESOURCES_EMPTY_SEARCH_MESSAGE" = "No matches found";
 
 
 // MARK: FHIR Resource Summary


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Makes the FHIR resource list searchable

## :recycle: Current situation & Problem
The list of FHIR resources is currently not searchable.

## :bulb: Proposed solution
Adds a search field that filters the list of FHIR resources.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

