### PR TITLE
Fixes a navigation issue in FHIRResourcesView

### DIFF
--- a/LLMonFHIR.xcodeproj/project.pbxproj
+++ b/LLMonFHIR.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		27D2125C2A30BB5900486694 /* FHIRResource+Search.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27D2125B2A30BB5900486694 /* FHIRResource+Search.swift */; };
+		27F7730B2A327FBC004D476D /* FHIRDisplayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F7730A2A327FBC004D476D /* FHIRDisplayTests.swift */; };
 		2F0F90BA2A1E6556006D7E03 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0F90B92A1E6556006D7E03 /* SettingsView.swift */; };
 		2F0F90BC2A1E6B19006D7E03 /* PromptSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0F90BB2A1E6B19006D7E03 /* PromptSettingsView.swift */; };
 		2F0F90BE2A1E702B006D7E03 /* Prompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0F90BD2A1E702B006D7E03 /* Prompt.swift */; };
@@ -69,6 +70,7 @@
 
 /* Begin PBXFileReference section */
 		27D2125B2A30BB5900486694 /* FHIRResource+Search.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FHIRResource+Search.swift"; sourceTree = "<group>"; };
+		27F7730A2A327FBC004D476D /* FHIRDisplayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FHIRDisplayTests.swift; sourceTree = "<group>"; };
 		2F0F90B92A1E6556006D7E03 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		2F0F90BB2A1E6B19006D7E03 /* PromptSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptSettingsView.swift; sourceTree = "<group>"; };
 		2F0F90BD2A1E702B006D7E03 /* Prompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prompt.swift; sourceTree = "<group>"; };
@@ -278,6 +280,7 @@
 			isa = PBXGroup;
 			children = (
 				2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */,
+				27F7730A2A327FBC004D476D /* FHIRDisplayTests.swift */,
 			);
 			path = LLMonFHIRUITests;
 			sourceTree = "<group>";
@@ -509,6 +512,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2F4E237E2989A2FE0013F3D9 /* OnboardingTests.swift in Sources */,
+				27F7730B2A327FBC004D476D /* FHIRDisplayTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/LLMonFHIR/FHIR Display/FHIRResourcesView.swift
+++ b/LLMonFHIR/FHIR Display/FHIRResourcesView.swift
@@ -34,7 +34,7 @@ struct FHIRResourcesView: View {
             }
                 .searchable(text: $searchText)
                 .navigationDestination(for: FHIRResource.self) { resource in
-                    InspecResourceView(resource: resource)
+                    InspectResourceView(resource: resource)
                 }
                 .onReceive(fhirStandard.objectWillChange) {
                     loadFHIRResources()
@@ -113,7 +113,7 @@ struct FHIRResourcesView: View {
         let filteredResources = (resources[resourceType] ?? []).filterByDisplayName(with: searchText)
 
         return ForEach(filteredResources) { resource in
-            NavigationLink(destination: ResourceSummaryView(resource: resource)) {
+            NavigationLink(value: resource) {
                 ResourceSummaryView(resource: resource)
             }
         }

--- a/LLMonFHIR/FHIR Display/FHIRResourcesView.swift
+++ b/LLMonFHIR/FHIR Display/FHIRResourcesView.swift
@@ -46,16 +46,7 @@ struct FHIRResourcesView: View {
                     }
                 }
                 .toolbar {
-                    ToolbarItem(placement: .primaryAction) {
-                        Button(
-                            action: {
-                                showSettings.toggle()
-                            },
-                            label: {
-                                Image(systemName: "gear")
-                            }
-                        )
-                    }
+                    settingsToolbarItem()
                 }
                 .sheet(isPresented: $showSettings) {
                     SettingsView()
@@ -63,7 +54,7 @@ struct FHIRResourcesView: View {
                 .navigationTitle("FHIR_RESOURCES_TITLE")
         }
     }
-    
+
     @ViewBuilder
     private var instructionsView: some View {
         if resources.isEmpty {
@@ -112,6 +103,19 @@ struct FHIRResourcesView: View {
                 return false
             }
             return !resourceArray.filterByDisplayName(with: searchText).isEmpty
+        }
+    }
+
+    func settingsToolbarItem() -> some ToolbarContent {
+        ToolbarItem(placement: .primaryAction) {
+            Button(
+                action: {
+                    showSettings.toggle()
+                },
+                label: {
+                    Image(systemName: "gear")
+                }
+            )
         }
     }
 

--- a/LLMonFHIR/FHIR Display/InspectResourceView.swift
+++ b/LLMonFHIR/FHIR Display/InspectResourceView.swift
@@ -10,7 +10,7 @@ import SpeziViews
 import SwiftUI
 
 
-struct InspecResourceView: View {
+struct InspectResourceView: View {
     @EnvironmentObject var fhirResourceInterpreter: FHIRResourceInterpreter<FHIR>
     @EnvironmentObject var fhirResourceSummary: FHIRResourceSummary<FHIR>
     

--- a/LLMonFHIR/SharedContext/FeatureFlags.swift
+++ b/LLMonFHIR/SharedContext/FeatureFlags.swift
@@ -12,4 +12,6 @@ enum FeatureFlags {
     static let skipOnboarding = CommandLine.arguments.contains("--skipOnboarding")
     /// Always show the onboarding when the application is launched. Makes it easy to modify and test the onboarding flow without the need to manually remove the application or reset the simulator.
     static let showOnboarding = CommandLine.arguments.contains("--showOnboarding")
+    /// Sets the application in test mode
+    static let testMode = CommandLine.arguments.contains("--testMode")
 }

--- a/LLMonFHIRUITests/FHIRDisplayTests.swift
+++ b/LLMonFHIRUITests/FHIRDisplayTests.swift
@@ -1,0 +1,36 @@
+//
+// This source file is part of the Stanford LLM on FHIR project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+
+
+final class FHIRDisplayTests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+
+        continueAfterFailure = false
+
+        let app = XCUIApplication()
+        app.launchArguments = ["--skipOnboarding"]
+        app.deleteAndLaunch(withSpringboardAppName: "LLMonFHIR")
+    }
+
+    func testFHIRResourcesView() throws {
+        let app = XCUIApplication()
+        app.launchArguments = ["--skipOnboarding", "--testMode"]
+        app.launch()
+
+        let mockResource = app.otherElements.buttons["Mock Resource"]
+        XCTAssertTrue(mockResource.exists, "The 'Mock Resource' does not exist.")
+
+        mockResource.tap()
+        sleep(2)
+        let newScreenMockResourceText = app.staticTexts["Mock Resource"]
+        XCTAssertTrue(newScreenMockResourceText.exists, "The 'Mock Resource' text does not exist on the new screen.")
+    }
+}

--- a/LLMonFHIRUITests/FHIRDisplayTests.swift
+++ b/LLMonFHIRUITests/FHIRDisplayTests.swift
@@ -16,14 +16,12 @@ final class FHIRDisplayTests: XCTestCase {
         continueAfterFailure = false
 
         let app = XCUIApplication()
-        app.launchArguments = ["--skipOnboarding"]
+        app.launchArguments = ["--skipOnboarding", "--testMode"]
         app.deleteAndLaunch(withSpringboardAppName: "LLMonFHIR")
     }
 
     func testFHIRResourcesView() throws {
         let app = XCUIApplication()
-        app.launchArguments = ["--skipOnboarding", "--testMode"]
-        app.launch()
 
         let mockResource = app.otherElements.buttons["Mock Resource"]
         XCTAssertTrue(mockResource.exists, "The 'Mock Resource' does not exist.")


### PR DESCRIPTION
<!--

This source file is part of the Stanford Biodesign for Digital Health open-source project

SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Fixes a navigation issue in FHIRResourcesView

## :recycle: Current situation & Problem
When navigating between the `FHIRResourcesView` and `InspectResourceView`, the resource data appears incompletely due to a bug in the last PR. This PR also adds a UI test.

## :bulb: Proposed solution
Fixes the navigation issue.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).

