### PR TITLE
Disable `--testMode` flag on Run

### DIFF
--- a/LLMonFHIR.xcodeproj/xcshareddata/xcschemes/LLMonFHIR.xcscheme
+++ b/LLMonFHIR.xcodeproj/xcshareddata/xcschemes/LLMonFHIR.xcscheme
@@ -87,7 +87,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--testMode"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
    </LaunchAction>


### PR DESCRIPTION
# Disable `--testMode` flag on Run

## :recycle: Current situation & Problem
When this flag was enabled, Home was populated with a mock resource intended only for UI testing purposes. This mock resource blocked other mocked resources from Settings from being persisted on Home after they were selected.

https://github.com/user-attachments/assets/470d05f7-c418-459a-879f-4b7e8f41aff3

## :gear: Release Notes 
- Disable `--testMode` flag on Run.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
