### PR TITLE
Add chat export functionality

### DIFF
--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
@@ -42,6 +42,7 @@ struct MultipleResourcesChatView: View {
                     set: { llm.context.chat = $0 }
                 ),
                 disableInput: llm.state.representation == .processing,
+                exportFormat: .text,
                 messagePendingAnimation: .automatic
             )
             .speak(llm.context.chat, muted: !textToSpeech)


### PR DESCRIPTION
# Add chat export functionality

## :recycle: Current situation & Problem
Without a chat export feature, users cannot save or reference their conversation history, leading to lost information and manual copy-pasting workarounds.

## :gear: Release Notes 
Added a feature to export chat conversations in text format.


## :books: Documentation
N/A


## :white_check_mark: Testing
N/A


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
