### PR TITLE
Add Survey Results to Export-Ready Chat

### DIFF
--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/Survey.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/Survey.swift
@@ -192,16 +192,8 @@ final class Survey {
 // MARK: - Survey Report Generation
 
 extension Survey {
-    /// Generates a report file containing all survey responses
-    /// - Returns: URL to the generated report file
-    func generateReportFile() -> URL {
-        let reportContent = generateReport()
-        let tempDir = FileManager.default.temporaryDirectory
-        let reportURL = tempDir.appendingPathComponent("survey_report.txt")
-        try? reportContent.write(to: reportURL, atomically: true, encoding: .utf8)
-        return reportURL
-    }
-
+    /// Generates a report containing all survey responses, formatted for readability
+    /// - Returns: A formatted string suitable for export or display, with each component on a new line
     func generateReport() -> String {
         var report = ["Survey Results\n"]
 

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/Survey.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/Survey.swift
@@ -202,7 +202,7 @@ extension Survey {
         return reportURL
     }
 
-    private func generateReport() -> String {
+    func generateReport() -> String {
         var report = ["Survey Results\n"]
 
         for task in tasks {

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/UserStudyChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/UserStudyChatView.swift
@@ -93,12 +93,6 @@ final class UserStudyViewModel: ObservableObject {
         currentTaskNumber = 1
     }
 
-    /// Generates a report file for the completed study
-    /// - Returns: A shareable file containing the study results
-    func generateReportURL() -> URL {
-        survey.generateReportFile()
-    }
-
     /// Generates a formatted string for the completed study
     /// - Returns: A formatted string containing the study results
     func generateReport() -> String {

--- a/LLMonFHIR/Resources/Localizable.xcstrings
+++ b/LLMonFHIR/Resources/Localizable.xcstrings
@@ -2499,9 +2499,6 @@
         }
       }
     },
-    "Share Results" : {
-
-    },
     "Start Session" : {
 
     },


### PR DESCRIPTION
# Add Survey Results to Export-Ready Chat

## :gear: Release Notes 
The chat export file includes details from the survey report generated during the user study.

Given the nature of `ChatView`, a quick and simple solution is to create a `ChatEntity`, hidden from the UI, that stores survey report details. This `ChatEntity` is appended once the survey is complete, allowing both contents to be combined into a single file. A more refined approach would be to allow the chat to provide a formatted string, enabling us to handle the final formatting ourselves.

cc: @philippzagar 

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
