### PR TITLE
Enhance Likert Scale Response Option Labels

### DIFF
--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/SurveyView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/SurveyView.swift
@@ -112,10 +112,10 @@ struct QuestionSectionView: View {
 
     @ViewBuilder private var questionContent: some View {
         switch question.type {
-        case .likertScale(let range):
+        case .likertScale(let responseOptions):
             LikertScaleQuestionView(
-                range: range,
                 index: index,
+                responseOptions: responseOptions,
                 answerState: answerState
             )
         case .freeText:
@@ -178,22 +178,18 @@ struct RadioSelectionView: View {
 
 /// A view for collecting Likert scale responses
 struct LikertScaleQuestionView: View {
-    /// The valid range for this Likert scale
-    let range: ClosedRange<Int>
-
     /// The index of this question
     let index: Int
+
+    /// The response options for this question
+    let responseOptions: [String]
 
     /// The shared state object for managing answers
     @ObservedObject var answerState: SurveyAnswerState
 
-    private let explanations: [Int: String] = [
-        1: "Strongly Disagree",
-        2: "Disagree",
-        3: "Neutral",
-        4: "Agree",
-        5: "Strongly Agree"
-    ]
+    private var range: ClosedRange<Int> {
+        1...responseOptions.count
+    }
 
 
     var body: some View {
@@ -201,7 +197,10 @@ struct LikertScaleQuestionView: View {
             range: range,
             selectedValue: answerState.likertScaleAnswers[index],
             displayText: { value in
-                explanations[value] ?? ""
+                guard value > 0 && value <= responseOptions.count else {
+                    return ""
+                }
+                return responseOptions[value - 1]
             },
             onSelect: { value in
                 answerState.updateLikertScale(value: value, at: index)
@@ -250,8 +249,8 @@ struct NPSQuestionView: View {
             selectedValue: answerState.npsAnswer,
             displayText: { value in
                 switch value {
-                case 0: return "\(value) (Would not Recommend)"
-                case 10: return "\(value) (Would Recommend)"
+                case 0: return "\(value) (Would not recommend)"
+                case 10: return "\(value) (Would recommend)"
                 default: return "\(value)"
                 }
             },

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/UserStudyWelcomeView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/UserStudyWelcomeView.swift
@@ -145,30 +145,54 @@ extension AccessGuardConfiguration.Identifier {
 }
 
 extension [SurveyTask] {
+    private static let clarityScale = [
+        "Extremely unclear",
+        "Pretty unclear",
+        "Neutral",
+        "Pretty clear",
+        "Extremely clear"
+    ]
+
+    private static let effectivenessScale = [
+        "Extremely ineffective",
+        "Pretty ineffective",
+        "Neutral",
+        "Pretty effective",
+        "Extremely effective"
+    ]
+
+    private static let comparisonScale = [
+        "Much worse",
+        "A little bit worse",
+        "Neutral",
+        "A little bit better",
+        "Much better"
+    ]
+
     /// Default set of survey tasks used in the user study
     static let defaultTasks: [SurveyTask] = [
         .init(id: 1, questions: [
             .init(
                 text: "How clear and understandable was the summary provided by the app?",
-                type: .likertScale(range: 1...5)
+                type: .likertScale(responseOptions: clarityScale)
             )
         ]),
         .init(id: 2, questions: [
             .init(
                 text: "How effective is this feature for interpreting and evaluating your medical information?",
-                type: .likertScale(range: 1...5)
+                type: .likertScale(responseOptions: effectivenessScale)
             )
         ]),
         .init(id: 3, questions: [
             .init(
                 text: "How effective are these recommendations in helping you make decisions about your health?",
-                type: .likertScale(range: 1...5)
+                type: .likertScale(responseOptions: effectivenessScale)
             )
         ]),
         .init(id: 4, questions: [
             .init(
                 text: "How effective are these recommendations in helping you make decisions about your health?",
-                type: .likertScale(range: 1...5),
+                type: .likertScale(responseOptions: effectivenessScale),
                 isOptional: true
             ),
             .init(
@@ -180,7 +204,7 @@ extension [SurveyTask] {
         .init(id: 5, questions: [
             .init(
                 text: "Compared to other sources of health information (e.g., websites, doctors), how do you rate the LLM's responses?",
-                type: .likertScale(range: 1...5)
+                type: .likertScale(responseOptions: comparisonScale)
             ),
             .init(
                 text: "What were the most and least useful features of the LLM? Do you have any suggestions that you would like to share?",


### PR DESCRIPTION
# Enhance Likert Scale Response Option Labels

## :recycle: Current situation & Problem
Previously, all Likert scale questions used the same generic response options regardless of context:

```swift
    1: "Strongly Disagree"
    2: "Disagree"
    3: "Neutral"
    4: "Agree"
    5: "Strongly Agree"
```

This one-size-fits-all approach limited the relevance and clarity of survey responses, as many questions weren't asking about agreement (e.g., questions about clarity, effectiveness, or comparison).

## :gear: Release Notes 
This PR introduces context-specific response options tailored to each question type. Now, each Likert scale question has response options that directly relate to what's being asked.

|                                                                                           |                                                                                           |                                                                                           |
|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
| <img src="https://github.com/user-attachments/assets/ed8e6f36-4d0b-4333-af58-9d0f55aa4923" width="200"> | <img src="https://github.com/user-attachments/assets/fd13a965-ce25-4926-945f-e7b0d8ccd8b5" width="200"> | <img src="https://github.com/user-attachments/assets/86662fe2-d590-4878-ba20-962edfefa4d5" width="200"> |
| <img src="https://github.com/user-attachments/assets/ff10a0cf-035d-4f37-879a-ebdb0c240854" width="200"> | <img src="https://github.com/user-attachments/assets/aa2d9970-cf9d-4e4e-a714-b603f9dfcae9" width="200"> |

## :books: Documentation
Code documentation is added in code.


## :white_check_mark: Testing
N/A


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
