### PR TITLE
Incorporate Clinical Document References Such as Discharge Reports, Clinical Notes, and More

### DIFF
--- a/.github/workflows/user-study-beta-deployment.yml
+++ b/.github/workflows/user-study-beta-deployment.yml
@@ -6,10 +6,14 @@
 # SPDX-License-Identifier: MIT
 #
 
-
 name: User Study Beta Deployment
+
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
+
 jobs:
   buildandtest:
     name: Build and Test

--- a/LLMonFHIR.xcodeproj/project.pbxproj
+++ b/LLMonFHIR.xcodeproj/project.pbxproj
@@ -1167,7 +1167,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/Spezi";
 			requirement = {
-				kind = upToNextMinorVersion;
+				kind = upToNextMajorVersion;
 				minimumVersion = 1.8.0;
 			};
 		};
@@ -1183,7 +1183,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordBDHG/HealthKitOnFHIR.git";
 			requirement = {
-				kind = upToNextMinorVersion;
+				kind = upToNextMajorVersion;
 				minimumVersion = 0.2.11;
 			};
 		};
@@ -1231,7 +1231,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziChat";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 0.2.1;
 			};
 		};
@@ -1255,7 +1255,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziAccessGuard";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 0.3.3;
 			};
 		};
@@ -1263,7 +1263,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziLLM";
 			requirement = {
-				kind = upToNextMajorVersion;
+				kind = upToNextMinorVersion;
 				minimumVersion = 0.10.0;
 			};
 		};
@@ -1271,8 +1271,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFHIR";
 			requirement = {
-				branch = clinicalNotes;
-				kind = branch;
+				kind = revision;
+				revision = 1c67e8107508af2cdb3791689b934563fa9e46ae;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/LLMonFHIR.xcodeproj/project.pbxproj
+++ b/LLMonFHIR.xcodeproj/project.pbxproj
@@ -428,11 +428,11 @@
 				653A2549283387FE005D4D48 /* Sources */,
 				653A254A283387FE005D4D48 /* Frameworks */,
 				653A254B283387FE005D4D48 /* Resources */,
-				2F5B528D29BD237B002020B7 /* ShellScript */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				65A965182D7D21EC00F42471 /* PBXTargetDependency */,
 			);
 			name = LLMonFHIR;
 			packageProductDependencies = (
@@ -518,7 +518,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1340;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 1620;
 				TargetAttributes = {
 					653A254C283387FE005D4D48 = {
 						CreatedOnToolsVersion = 13.4;
@@ -560,6 +560,7 @@
 				C0FA07222D3932FB002485FF /* XCRemoteSwiftPackageReference "SpeziLLM" */,
 				C0FA07242D39357B002485FF /* XCRemoteSwiftPackageReference "SpeziFHIR" */,
 				C01EADB52D686A3000B559E9 /* XCRemoteSwiftPackageReference "SpeziAccessGuard" */,
+				65A965162D7D21C400F42471 /* XCRemoteSwiftPackageReference "SwiftLint" */,
 			);
 			productRefGroup = 653A254E283387FE005D4D48 /* Products */;
 			projectDirPath = "";
@@ -598,27 +599,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		2F5B528D29BD237B002020B7 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-			);
-			inputPaths = (
-			);
-			outputFileListPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "if [ \"${CONFIGURATION}\" = \"Debug\" ]; then\n  export PATH=\"$PATH:/opt/homebrew/bin\"\n  if which swiftlint > /dev/null; then\n    swiftlint\n  else\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\n  fi\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		653A2549283387FE005D4D48 /* Sources */ = {
@@ -698,6 +678,10 @@
 			target = 653A254C283387FE005D4D48 /* LLMonFHIR */;
 			targetProxy = 653A256828338800005D4D48 /* PBXContainerItemProxy */;
 		};
+		65A965182D7D21EC00F42471 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 65A965172D7D21EC00F42471 /* SwiftLintBuildToolPlugin */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
@@ -739,6 +723,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -774,7 +759,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = CJ6GKG29BS;
+				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "LLMonFHIR/Supporting Files/Info.plist";
@@ -797,7 +782,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = im.nissen.llmonfhir;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.bdhg.llmonfhir;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -813,7 +798,6 @@
 		2FEE10322998C89C000822E1 /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -832,7 +816,6 @@
 		2FEE10332998C89C000822E1 /* Test */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;
@@ -885,6 +868,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -948,6 +932,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -977,7 +962,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = CJ6GKG29BS;
+				DEVELOPMENT_TEAM = 637867499T;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "LLMonFHIR/Supporting Files/Info.plist";
@@ -1000,7 +985,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = im.nissen.llmonfhir;
+				PRODUCT_BUNDLE_IDENTIFIER = edu.stanford.bdhg.llmonfhir;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
@@ -1065,7 +1050,6 @@
 		653A257528338800005D4D48 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1084,7 +1068,6 @@
 		653A257628338800005D4D48 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -1103,7 +1086,6 @@
 		653A257828338800005D4D48 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;
@@ -1121,7 +1103,6 @@
 		653A257928338800005D4D48 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 637867499T;
@@ -1262,6 +1243,14 @@
 				minimumVersion = 1.1.1;
 			};
 		};
+		65A965162D7D21C400F42471 /* XCRemoteSwiftPackageReference "SwiftLint" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/realm/SwiftLint";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.58.2;
+			};
+		};
 		C01EADB52D686A3000B559E9 /* XCRemoteSwiftPackageReference "SpeziAccessGuard" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziAccessGuard";
@@ -1282,8 +1271,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFHIR";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 0.7.0;
+				branch = clinicalNotes;
+				kind = branch;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -1353,6 +1342,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 44E18E912CEBF26800829A26 /* XCRemoteSwiftPackageReference "SpeziStorage" */;
 			productName = SpeziLocalStorage;
+		};
+		65A965172D7D21EC00F42471 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 65A965162D7D21C400F42471 /* XCRemoteSwiftPackageReference "SwiftLint" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
 		};
 		9710D3552B84151F00E0A20F /* SpeziChat */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/LLMonFHIR.xcodeproj/project.pbxproj
+++ b/LLMonFHIR.xcodeproj/project.pbxproj
@@ -1271,8 +1271,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFHIR";
 			requirement = {
-				kind = revision;
-				revision = 3e2967d6afe20d1931678e2d57ce97eac39b0077;
+				kind = upToNextMinorVersion;
+				minimumVersion = 0.7.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/LLMonFHIR.xcodeproj/project.pbxproj
+++ b/LLMonFHIR.xcodeproj/project.pbxproj
@@ -1272,7 +1272,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFHIR";
 			requirement = {
 				kind = revision;
-				revision = 2eaa5503cdf5b3d7d8fa878fe8274bae722bf040;
+				revision = 3e2967d6afe20d1931678e2d57ce97eac39b0077;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/LLMonFHIR.xcodeproj/project.pbxproj
+++ b/LLMonFHIR.xcodeproj/project.pbxproj
@@ -1272,7 +1272,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFHIR";
 			requirement = {
 				kind = revision;
-				revision = 1c67e8107508af2cdb3791689b934563fa9e46ae;
+				revision = 2eaa5503cdf5b3d7d8fa878fe8274bae722bf040;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,7 +123,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFHIR",
       "state" : {
-        "revision" : "2eaa5503cdf5b3d7d8fa878fe8274bae722bf040"
+        "revision" : "3e2967d6afe20d1931678e2d57ce97eac39b0077"
       }
     },
     {

--- a/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,24 @@
 {
-  "originHash" : "1cb8efdae8edea3defb6af6969855edb976e17f0a15c6c257e184cdaea49f51c",
+  "originHash" : "06510e082c09c3b7e3ac410828c63fa1a11cf43d094c19cc60fd06c93a32cef1",
   "pins" : [
+    {
+      "identity" : "collectionconcurrencykit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/JohnSundell/CollectionConcurrencyKit.git",
+      "state" : {
+        "revision" : "b4f23e24b5a1bff301efc5e70871083ca029ff95",
+        "version" : "0.2.0"
+      }
+    },
+    {
+      "identity" : "cryptoswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/krzyzanowskim/CryptoSwift.git",
+      "state" : {
+        "revision" : "729e01bc9b9dab466ac85f21fb9ee2bc1c61b258",
+        "version" : "1.8.4"
+      }
+    },
     {
       "identity" : "fhirmodels",
       "kind" : "remoteSourceControl",
@@ -65,6 +83,15 @@
       }
     },
     {
+      "identity" : "sourcekitten",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/jpsim/SourceKitten.git",
+      "state" : {
+        "revision" : "fd4df99170f5e9d7cf9aa8312aa8506e0e7a44e7",
+        "version" : "0.35.0"
+      }
+    },
+    {
       "identity" : "spezi",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/Spezi",
@@ -96,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFHIR",
       "state" : {
-        "revision" : "a2e68a2e8d2f86dbe03c52ba4f9a99dbbcf137fa",
-        "version" : "0.7.0"
+        "branch" : "clinicalNotes",
+        "revision" : "fecb407d844e9d3072ae7714546269d4aeed83b2"
       }
     },
     {
@@ -245,12 +272,48 @@
       }
     },
     {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax.git",
+      "state" : {
+        "revision" : "cb53fa1bd3219b0b23ded7dfdd3b2baff266fd25",
+        "version" : "600.0.0"
+      }
+    },
+    {
       "identity" : "swift-transformers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
         "revision" : "d42fdae473c49ea216671da8caae58e102d28709",
         "version" : "0.1.14"
+      }
+    },
+    {
+      "identity" : "swiftlint",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/realm/SwiftLint",
+      "state" : {
+        "revision" : "eba420f77846e93beb98d516b225abeb2fef4ca2",
+        "version" : "0.58.2"
+      }
+    },
+    {
+      "identity" : "swiftytexttable",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/scottrhoyt/SwiftyTextTable.git",
+      "state" : {
+        "revision" : "c6df6cf533d120716bff38f8ff9885e1ce2a4ac3",
+        "version" : "0.9.0"
+      }
+    },
+    {
+      "identity" : "swxmlhash",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/drmohundro/SWXMLHash.git",
+      "state" : {
+        "revision" : "a853604c9e9a83ad9954c7e3d2a565273982471f",
+        "version" : "7.0.2"
       }
     },
     {

--- a/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,7 +123,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFHIR",
       "state" : {
-        "revision" : "1c67e8107508af2cdb3791689b934563fa9e46ae"
+        "revision" : "2eaa5503cdf5b3d7d8fa878fe8274bae722bf040"
       }
     },
     {

--- a/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -123,7 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFHIR",
       "state" : {
-        "revision" : "3e2967d6afe20d1931678e2d57ce97eac39b0077"
+        "revision" : "cc83cce380a587c3ad1a1309425f2cb64b6a9f4a",
+        "version" : "0.7.3"
       }
     },
     {

--- a/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "06510e082c09c3b7e3ac410828c63fa1a11cf43d094c19cc60fd06c93a32cef1",
+  "originHash" : "065a78a0fbd76259f6e2dfbe31b9495b32f90d0df81787c26e41278e93557c5c",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -42,17 +42,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordBDHG/HealthKitOnFHIR.git",
       "state" : {
-        "revision" : "87a9257e6fa37407f3437e4a0bf21dd09a4ea7c5",
-        "version" : "0.2.11"
+        "revision" : "c898c0bace660ecae37fc682d629f7883f92e700",
+        "version" : "0.2.13"
       }
     },
     {
       "identity" : "jinja",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/maiqingqiang/Jinja",
+      "location" : "https://github.com/johnmai-dev/Jinja",
       "state" : {
-        "revision" : "6dbe4c449469fb586d0f7339f900f0dd4d78b167",
-        "version" : "1.0.6"
+        "revision" : "bbddb92fc51ae420b87300298370fd1dfc308f73",
+        "version" : "1.1.1"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ml-explore/mlx-swift",
       "state" : {
-        "revision" : "70dbb62128a5a1471a5ab80363430adb33470cab",
-        "version" : "0.21.2"
+        "revision" : "b990c58153af70eb0914bca7dd74401d341fa9ae",
+        "version" : "0.21.3"
       }
     },
     {
@@ -123,8 +123,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFHIR",
       "state" : {
-        "branch" : "clinicalNotes",
-        "revision" : "fecb407d844e9d3072ae7714546269d4aeed83b2"
+        "revision" : "1c67e8107508af2cdb3791689b934563fa9e46ae"
       }
     },
     {
@@ -132,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFoundation",
       "state" : {
-        "revision" : "c844b98242829fe44e7908739374d4c8b88d6da7",
-        "version" : "2.1.0"
+        "revision" : "78f3d912a82f951564d7e133867cf01351f53062",
+        "version" : "2.1.1"
       }
     },
     {
@@ -150,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziLLM",
       "state" : {
-        "revision" : "6119ae95033dbb362e02efc0bb4335f560f96f3f",
-        "version" : "0.10.0"
+        "revision" : "61b664bf019032634a6eeacff89afa1ea7d545fd",
+        "version" : "0.10.1"
       }
     },
     {
@@ -166,10 +165,10 @@
     {
       "identity" : "spezispeech",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/StanfordSpezi/SpeziSpeech.git",
+      "location" : "https://github.com/StanfordSpezi/SpeziSpeech",
       "state" : {
-        "revision" : "3becc70cb1399af9ff954bea22711bb043c517d4",
-        "version" : "1.1.1"
+        "revision" : "6c51d4165d2cabb6102aa61233c480fb75c167f6",
+        "version" : "1.1.2"
       }
     },
     {
@@ -186,8 +185,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziViews",
       "state" : {
-        "revision" : "80c7cdfd5e50c3e279ab889cc90bbcfc88c4f24c",
-        "version" : "1.9.0"
+        "revision" : "76be1e28a88c9a102524aded45f6c76850266110",
+        "version" : "1.9.1"
       }
     },
     {
@@ -240,8 +239,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-numerics",
       "state" : {
-        "revision" : "0a5bc04095a675662cf24757cc0640aa2204253b",
-        "version" : "1.0.2"
+        "revision" : "e0ec0f5f3af6f3e4d5e7a19d2af26b481acb6ba8",
+        "version" : "1.0.3"
       }
     },
     {
@@ -285,8 +284,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-transformers",
       "state" : {
-        "revision" : "d42fdae473c49ea216671da8caae58e102d28709",
-        "version" : "0.1.14"
+        "revision" : "8a83416cc00ab07a5de9991e6ad817a9b8588d20",
+        "version" : "0.1.15"
       }
     },
     {

--- a/LLMonFHIR.xcodeproj/xcshareddata/xcschemes/LLMonFHIR.xcscheme
+++ b/LLMonFHIR.xcodeproj/xcshareddata/xcschemes/LLMonFHIR.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1530"
+   LastUpgradeVersion = "1620"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/LLMonFHIR/FHIR Views/FHIRResourcesView.swift
+++ b/LLMonFHIR/FHIR Views/FHIRResourcesView.swift
@@ -76,8 +76,10 @@ struct FHIRResourcesView<ContentView: View, ActionView: View>: View {
     }
     
     @ViewBuilder private var resourcesSection: some View {
+        section(for: \.allergyIntolerances, sectionName: String(localized: "Conditions"))
         section(for: \.conditions, sectionName: String(localized: "Conditions"))
         section(for: \.diagnostics, sectionName: String(localized: "Diagnostics"))
+        section(for: \.documents, sectionName: String(localized: "Diagnostics"))
         section(for: \.encounters, sectionName: String(localized: "Encounters"))
         section(for: \.immunizations, sectionName: String(localized: "Immunizations"))
         section(for: \.medications, sectionName: String(localized: "Medications"))

--- a/LLMonFHIR/FHIR Views/FHIRResourcesView.swift
+++ b/LLMonFHIR/FHIR Views/FHIRResourcesView.swift
@@ -76,10 +76,10 @@ struct FHIRResourcesView<ContentView: View, ActionView: View>: View {
     }
     
     @ViewBuilder private var resourcesSection: some View {
-        section(for: \.allergyIntolerances, sectionName: String(localized: "Conditions"))
+        section(for: \.allergyIntolerances, sectionName: String(localized: "Allergies"))
         section(for: \.conditions, sectionName: String(localized: "Conditions"))
         section(for: \.diagnostics, sectionName: String(localized: "Diagnostics"))
-        section(for: \.documents, sectionName: String(localized: "Diagnostics"))
+        section(for: \.documents, sectionName: String(localized: "Documents"))
         section(for: \.encounters, sectionName: String(localized: "Encounters"))
         section(for: \.immunizations, sectionName: String(localized: "Immunizations"))
         section(for: \.medications, sectionName: String(localized: "Medications"))

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/FHIRGetResourceLLMFunction.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/FHIRGetResourceLLMFunction.swift
@@ -24,6 +24,7 @@ struct FHIRGetResourceLLMFunction: LLMFunction {
     @Parameter var resources: [String]
     
     
+    @MainActor
     init(
         fhirStore: FHIRStore,
         resourceSummary: FHIRResourceSummary,
@@ -74,7 +75,7 @@ struct FHIRGetResourceLLMFunction: LLMFunction {
             for requestedResource in resources {
                 outerGroup.addTask { @Sendable [fhirStore, resourceSummary] in
                     // Fetch relevant FHIR resources matching the resources requested by the LLM
-                    var fittingResources = fhirStore.llmRelevantResources.filter { $0.functionCallIdentifier.contains(requestedResource) }
+                    var fittingResources = await fhirStore.llmRelevantResources.filter { $0.functionCallIdentifier.contains(requestedResource) }
                     
                     // Stores output of nested task group summarizing fitting resources
                     var nestedFunctionOutputResults = [String]()

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
@@ -45,6 +45,10 @@ class FHIRMultipleResourceInterpreter {
         self.llmRunner = llmRunner
         self.llmSchema = llmSchema
         self.fhirStore = fhirStore
+        
+        Task { @MainActor in
+            await prepareLLM()
+        }
     }
     
     

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
@@ -33,6 +33,7 @@ class FHIRMultipleResourceInterpreter {
     private let fhirStore: FHIRStore
     
     var llm: (any LLMSession)?
+    private(set) var viewState: ViewState = .idle
     
     
     required init(
@@ -54,11 +55,13 @@ class FHIRMultipleResourceInterpreter {
     
     @MainActor
     func resetChat() {
+        viewState = .processing
         llm = llmRunner(with: llmSchema)
         llm?.context.append(systemMessage: FHIRPrompt.interpretMultipleResources.prompt)
         if let patient = fhirStore.patient {
             llm?.context.append(systemMessage: patient.jsonDescription)
         }
+        viewState = .idle
     }
     
     @MainActor
@@ -67,6 +70,7 @@ class FHIRMultipleResourceInterpreter {
             return
         }
         
+        viewState = .processing
         let llm = llmRunner(with: llmSchema)
         // Read initial conversation from storage
         if let storedContext: LLMContext = try? localStorage.load(.init(FHIRMultipleResourceInterpreterConstants.context)) {
@@ -79,6 +83,7 @@ class FHIRMultipleResourceInterpreter {
         }
 
         self.llm = llm
+        viewState = .idle
     }
 
     @MainActor
@@ -88,19 +93,23 @@ class FHIRMultipleResourceInterpreter {
             return
         }
         
+        viewState = .processing
         Task {
-            Self.logger.debug("The Multiple Resource Interpreter has access to \(self.fhirStore.llmRelevantResources.count) resources.")
-            
-            guard let stream = try? await llm.generate() else {
-                return
+            do {
+                Self.logger.debug("The Multiple Resource Interpreter has access to \(self.fhirStore.llmRelevantResources.count) resources.")
+                
+                let stream = try await llm.generate()
+                
+                for try await token in stream {
+                    viewState = .idle
+                    llm.context.append(assistantOutput: token)
+                }
+                
+                // Store conversation to storage
+                try localStorage.store(llm.context, for: .init(FHIRMultipleResourceInterpreterConstants.context))
+            } catch {
+                viewState = .error(AnyLocalizedError(error: error))
             }
-            
-            for try await token in stream {
-                llm.context.append(assistantOutput: token)
-            }
-            
-            // Store conversation to storage
-            try localStorage.store(llm.context, for: .init(FHIRMultipleResourceInterpreterConstants.context))
         }
     }
     

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
@@ -45,14 +45,20 @@ struct MultipleResourcesChatView: View {
                 exportFormat: .text,
                 messagePendingAnimation: .automatic
             )
-            .speak(llm.context.chat, muted: !textToSpeech)
-            .speechToolbarButton(muted: !$textToSpeech)
-            .viewStateAlert(state: llm.state)
-            .onChange(of: llm.context) {
-                if llm.state != .generating {
-                    multipleResourceInterpreter.queryLLM()
+                .speak(llm.context.chat, muted: !textToSpeech)
+                .speechToolbarButton(muted: !$textToSpeech)
+                .viewStateAlert(state: llm.state)
+                .onChange(of: llm.context) {
+                    if llm.state != .generating {
+                        multipleResourceInterpreter.queryLLM()
+                    }
                 }
-            }
+                .onAppear {
+                    guard !llm.context.chat.contains(where: { $0.role == .user }) else {
+                        return
+                    }
+                    multipleResourceInterpreter.resetChat()
+                }
         } else {
             ProgressView()
         }

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
@@ -43,7 +43,7 @@ struct MultipleResourcesChatView: View {
                 ),
                 disableInput: llm.state.representation == .processing,
                 exportFormat: .text,
-                messagePendingAnimation: .automatic
+                messagePendingAnimation: .manual(shouldDisplay: multipleResourceInterpreter.viewState == .processing)
             )
                 .speak(llm.context.chat, muted: !textToSpeech)
                 .speechToolbarButton(muted: !$textToSpeech)

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/SurveyView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/UserStudy/SurveyView.swift
@@ -306,9 +306,12 @@ struct SurveyView: View {
         Button(action: handleSubmit) {
             Text("Submit")
                 .frame(maxWidth: .infinity)
+                .padding(4)
         }
-        .buttonStyle(.borderless)
-        .disabled(!areAllQuestionsAnswered)
+            .padding(.horizontal, -16)
+            .buttonStyle(.borderedProminent)
+            .disabled(!areAllQuestionsAnswered)
+            .listRowBackground(Color.clear)
     }
 
     private var cancelButton: some View {

--- a/LLMonFHIR/FHIRInterpretationModule.swift
+++ b/LLMonFHIR/FHIRInterpretationModule.swift
@@ -51,7 +51,7 @@ class FHIRInterpretationModule: Module, DefaultInitializable {
         summaryLLMSchema: SummaryLLM = Defaults.llmSchema,
         interpretationLLMSchema: InterpretationLLM = Defaults.llmSchema,    // swiftlint:disable:this function_default_parameter_at_end
         multipleResourceInterpretationOpenAIModel: LLMOpenAIParameters.ModelType,  // swiftlint:disable:this identifier_name
-        resourceCountLimit: Int = 250,
+        resourceCountLimit: Int = 300,
         allowedResourcesFunctionCallIdentifiers: Set<String>? = nil // swiftlint:disable:this discouraged_optional_collection
     ) {
         self.summaryLLMSchema = summaryLLMSchema
@@ -99,6 +99,7 @@ class FHIRInterpretationModule: Module, DefaultInitializable {
         )
     }
 
+    @MainActor
     private func createOpenAISchema() -> LLMOpenAISchema {
         LLMOpenAISchema(
             parameters: .init(

--- a/LLMonFHIR/FHIRInterpretationModule.swift
+++ b/LLMonFHIR/FHIRInterpretationModule.swift
@@ -51,7 +51,7 @@ class FHIRInterpretationModule: Module, DefaultInitializable {
         summaryLLMSchema: SummaryLLM = Defaults.llmSchema,
         interpretationLLMSchema: InterpretationLLM = Defaults.llmSchema,    // swiftlint:disable:this function_default_parameter_at_end
         multipleResourceInterpretationOpenAIModel: LLMOpenAIParameters.ModelType,  // swiftlint:disable:this identifier_name
-        resourceCountLimit: Int = 300,
+        resourceCountLimit: Int = 250,
         allowedResourcesFunctionCallIdentifiers: Set<String>? = nil // swiftlint:disable:this discouraged_optional_collection
     ) {
         self.summaryLLMSchema = summaryLLMSchema

--- a/LLMonFHIR/FHIRSummary/FHIRResourceSummary.swift
+++ b/LLMonFHIR/FHIRSummary/FHIRResourceSummary.swift
@@ -65,7 +65,9 @@ final class FHIRResourceSummary: Sendable {
     /// - Returns: An asynchronous `String` representing the summarization of the resource.
     @discardableResult
     func summarize(resource: FHIRResource, forceReload: Bool = false) async throws -> Summary {
-        try await resourceProcessor.process(resource: resource, forceReload: forceReload)
+        let resource = try resource.copy()
+        try await resource.stringifyAttachements()
+        return try await resourceProcessor.process(resource: resource, forceReload: forceReload)
     }
     
     /// Retrieve the cached summary of a given FHIR resource. Returns a human-readable summary or `nil` if it is not present.

--- a/LLMonFHIR/FHIRSummary/FHIRResourceSummary.swift
+++ b/LLMonFHIR/FHIRSummary/FHIRResourceSummary.swift
@@ -66,7 +66,7 @@ final class FHIRResourceSummary: Sendable {
     @discardableResult
     func summarize(resource: FHIRResource, forceReload: Bool = false) async throws -> Summary {
         let resource = try resource.copy()
-        try await resource.stringifyAttachements()
+        try? resource.stringifyAttachements()
         return try await resourceProcessor.process(resource: resource, forceReload: forceReload)
     }
     

--- a/LLMonFHIR/Helper/FHIRStore+Interpretation.swift
+++ b/LLMonFHIR/Helper/FHIRStore+Interpretation.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 extension FHIRStore {
     /// All relevant `FHIRResource`s for the LLM interpretation.
-    public var llmRelevantResources: [FHIRResource] {
+    @MainActor public var llmRelevantResources: [FHIRResource] {
         allergyIntolerances
             + llmConditions
             + encounters.uniqueDisplayNames
@@ -21,10 +21,11 @@ extension FHIRStore {
             + llmMedications
             + observations.uniqueDisplayNames
             + procedures.uniqueDisplayNames
+            + documents
     }
     
     /// All `FHIRResource`s.
-    public var allResources: [FHIRResource] {
+    @MainActor public var allResources: [FHIRResource] {
         allergyIntolerances
             + conditions
             + diagnostics
@@ -34,10 +35,11 @@ extension FHIRStore {
             + observations
             + otherResources
             + procedures
+            + documents
     }
     
     /// The patient `FHIRResource`
-    public var patient: FHIRResource? {
+    @MainActor public var patient: FHIRResource? {
         otherResources
             .first { resource in
                 guard case let .r4(resource) = resource.versionedResource,
@@ -49,7 +51,7 @@ extension FHIRStore {
             }
     }
     
-    private var llmConditions: [FHIRResource] {
+    @MainActor private var llmConditions: [FHIRResource] {
         conditions
             .filter { resource in
                 guard case let .r4(resource) = resource.versionedResource,
@@ -68,7 +70,7 @@ extension FHIRStore {
             }
     }
     
-    private var llmMedications: [FHIRResource] {
+    @MainActor private var llmMedications: [FHIRResource] {
         func medicationRequest(resource: FHIRResource) -> MedicationRequest? {
             guard case let .r4(resource) = resource.versionedResource,
                   let medicationRequest = resource as? ModelsR4.MedicationRequest else {
@@ -110,7 +112,7 @@ extension FHIRStore {
     /// Get the function call identifiers of all available health resources in the `FHIRStore`.
     ///
     /// - Tip: We use an array as the order indicates the sorting, oldest resources come first, newest one last
-    public var allResourcesFunctionCallIdentifier: [String] {
+    @MainActor public var allResourcesFunctionCallIdentifier: [String] {
         let relevantResources: [FHIRResource] = llmRelevantResources
             .lazy
             .filter {

--- a/LLMonFHIR/Helper/FHIRStore+Interpretation.swift
+++ b/LLMonFHIR/Helper/FHIRStore+Interpretation.swift
@@ -16,12 +16,14 @@ extension FHIRStore {
     @MainActor public var llmRelevantResources: [FHIRResource] {
         allergyIntolerances
             + llmConditions
+            + diagnostics.uniqueDisplayNames
+            + documents
             + encounters.uniqueDisplayNames
             + immunizations
             + llmMedications
             + observations.uniqueDisplayNames
             + procedures.uniqueDisplayNames
-            + documents
+            + otherResources.uniqueDisplayNames
     }
     
     /// All `FHIRResource`s.
@@ -29,13 +31,13 @@ extension FHIRStore {
         allergyIntolerances
             + conditions
             + diagnostics
+            + documents
             + encounters
             + immunizations
             + medications
             + observations
-            + otherResources
             + procedures
-            + documents
+            + otherResources
     }
     
     /// The patient `FHIRResource`

--- a/LLMonFHIR/LLMonFHIRStandard.swift
+++ b/LLMonFHIR/LLMonFHIRStandard.swift
@@ -21,6 +21,10 @@ actor LLMonFHIRStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
     
     
     func add(sample: HKSample) async {
+        await MainActor.run {
+            FHIRStore.loadHealthKitAttachements = true
+        }
+        
         samples.append(sample)
         if await useHealthKitResources {
             await fhirStore.add(sample: sample)

--- a/LLMonFHIR/LLMonFHIRStandard.swift
+++ b/LLMonFHIR/LLMonFHIRStandard.swift
@@ -21,13 +21,9 @@ actor LLMonFHIRStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
     
     
     func add(sample: HKSample) async {
-        await MainActor.run {
-            FHIRStore.loadHealthKitAttachements = true
-        }
-        
         samples.append(sample)
         if await useHealthKitResources {
-            await fhirStore.add(sample: sample)
+            await fhirStore.add(sample: sample, loadHealthKitAttachements: true)
         }
     }
     

--- a/LLMonFHIR/ResourceView.swift
+++ b/LLMonFHIR/ResourceView.swift
@@ -37,7 +37,7 @@ struct ResourceView: View {
         }
         .task {
             if FeatureFlags.testMode {
-                fhirStore.loadTestingResources()
+                await fhirStore.loadTestingResources()
             }
         }
     }

--- a/LLMonFHIR/Resources/Localizable.xcstrings
+++ b/LLMonFHIR/Resources/Localizable.xcstrings
@@ -7,6 +7,9 @@
     "A team member will be with you soon. During this study, you’ll complete a survey about your experiences navigating the healthcare system and have the opportunity to ask the chat questions about your health." : {
 
     },
+    "Allergies" : {
+
+    },
     "Approved by Stanford IRB" : {
 
     },
@@ -722,6 +725,9 @@
       }
     },
     "Do you want to continue?" : {
+
+    },
+    "Documents" : {
 
     },
     "Download the LLM model to generate summaries of FHIR resources." : {

--- a/LLMonFHIR/Resources/Localizable.xcstrings
+++ b/LLMonFHIR/Resources/Localizable.xcstrings
@@ -50,41 +50,6 @@
         }
       }
     },
-    "CHAT_WITH_ALL_RESOURCES_TITLE" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alle FHIR-Ressourcen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "All FHIR Resources"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Todos los Recursos FHIR"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toutes les Ressources FHIR"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "所有FHIR资源"
-          }
-        }
-      }
-    },
     "Checkmark" : {
 
     },
@@ -762,6 +727,9 @@
     "Download the LLM model to generate summaries of FHIR resources." : {
 
     },
+    "Enable Usability Study" : {
+
+    },
     "Encounters" : {
       "localizations" : {
         "de" : {
@@ -786,41 +754,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "邂逅"
-          }
-        }
-      }
-    },
-    "FHIR_RESOURCES_CHAT_CANCEL" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbrechen"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancel"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Annuler"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取消"
           }
         }
       }
@@ -889,41 +822,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "负载释义"
-          }
-        }
-      }
-    },
-    "FHIR_RESOURCES_INTERPRETATION_ERROR" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fehler"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Error"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erreur"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "错误"
           }
         }
       }
@@ -1060,41 +958,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "负荷资源汇总"
-          }
-        }
-      }
-    },
-    "FHIR_RESOURCES_SUMMARY_INSTRUCTION" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Drücken Sie die Ressource lange und wählen Sie \"Ressourcenzusammenfassung laden\", damit LLM on FHIR einen Titel und eine Zusammenfassung dieser Ressource erstellen kann."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Long press the resource and select \"Load Resource Summary\" to let LLM on FHIR create a title and summary of this resource."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pulse prolongadamente el recurso y seleccione \"Cargar Resumen del Recurso\" para que LLM en FHIR cree un título y un resumen de este recurso."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maintenez le doigt appuyé sur la ressource et sélectionnez \"Charger le Résumé de la Ressource\" pour que LLM sur FHIR crée un titre et un résumé de cette ressource."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "长按资源并选择“加载资源摘要”来让LLM on FHIR创建该资源的标题和摘要。"
           }
         }
       }
@@ -1548,31 +1411,31 @@
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Sie sind eine Anwendung, die die Aufgabe hat, FHIR-Ressourcen aus den Krankenakten des Benutzers zu interpretieren.\n\nVerwenden Sie während des gesamten Gesprächs mit dem Benutzer die Funktion \"get_resources\", um die FHIR-Gesundheitsressourcen zu erhalten, die für die ordnungsgemäße Beantwortung der Frage des Benutzers erforderlich sind. Wenn der Benutzer beispielsweise nach seinen Allergien fragt, müssen Sie die Funktion \"get_resources\" verwenden, um die FHIR-Ressourcentitel für Allergiedatensätze auszugeben, damit Sie diese dann zur Beantwortung der Frage verwenden können. Ziel ist es, die Frage des Benutzers bestmöglich zu beantworten und dabei die mit \"get_resources\" erhaltenen FHIR-Ressourcen zu berücksichtigen. Lassen Sie alle technischen Details wie JSON, FHIR-Ressourcen und andere Implementierungsdetails der zugrunde liegenden Datenressourcen weg.\nFordern Sie nur relevante Ressourcen an und konzentrieren Sie sich auf aktuelle Ressourcen. Versuchen Sie, die Anzahl der angeforderten Ressourcen auf ein vernünftiges Maß zu reduzieren.\nWenn der Benutzer z. B. nach seinen Medikamenten fragt, wäre es empfehlenswert, alle FHIR-Ressourcentypen MedicationRequest anzufordern.\n\nInterpretieren Sie die Ressourcen, indem Sie die für die Gesundheit des Benutzers relevanten Daten erklären. Erläutern Sie den relevanten medizinischen Kontext in einer Sprache, die für einen Benutzer, der kein Mediziner ist, verständlich ist, idealerweise auf dem Niveau der fünften Klasse. Sie sollten sachliche und präzise Informationen in einer kompakten Zusammenfassung in kurzen Antworten bereitstellen.\n\nDie Patientenressource wird als anfänglicher Kontext bereitgestellt. Stellen Sie sicher, dass Sie alle sensiblen Nummern wie SSN, Passnummer und Telefonnummer weglassen. \nStellen Sie sich nicht zu Beginn vor und geben Sie sofort eine Zusammenfassung des Benutzers auf der Grundlage der FHIR-Patientenressourcen zurück. Fordern Sie für Ihre erste Nachricht keine FHIR-Ressourcen über die Funktion \"get_resources\" an. Die erste Zusammenfassung sollte kurz und einfach sein; bleiben Sie auf einem hohen Niveau. Beenden Sie sie mit einer Frage an den Benutzer, ob er noch Fragen hat. Achten Sie darauf, dass Ihre Antwort in derselben Sprache verfasst ist, in der der Benutzer Ihnen schreibt, und nicht in der Sprache, die in der Patientenressource angegeben ist. Die Zeitform sollte das Präsens sein."
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "You are an application that is tasked with interpreting FHIR resources from the user's clinical records.\n\nThroughout the conversation with the user, use the \"get_resources\" function to obtain the FHIR health resources necessary to answer the user's question properly. For example, if the user asks about their allergies, you must use the \"get_resources\" function to output the FHIR resource titles for allergy records so you can then use them to answer the question. The end goal is to answer the user's question in the best way possible while taking the FHIR resources obtained using \"get_resources\" into consideration. Leave out any technical details like JSON, FHIR resources, and other implementation details of the underlying data resources.\nOnly request relevant resources and focus on recent resources. Try to reduce the number of requested resources to a reasonable scope.\nE.g. if the user asks about their Medication it would be recommended to request all MedicationRequest FHIR resource types.\n\nInterpret the resources by explaining the data relevant to the user's health. Explain the relevant medical context in a language understandable by a user who is not a medical professional, ideally at a 5th-grade reading level. You should provide factual and precise information in a compact summary in short responses.\n\nThe patient resource is provided as the initial context. Ensure to leave out any sensitive numbers like SSN, passport number, and telephone number. \nDo not introduce yourself at the beginning and immediately return a summary of the user based on the FHIR patient resources. No not request any FHIR resources using the \"get_resources\" function for your first message. The initial summary should be short and simple; stay at a high level. End with a question asking the user if they have any questions. Make sure your response is in the same language the user writes to you in, not the one stated in the patient resource. The tense should be present."
+            "value" : "You are the LLMonFHIR agent that is tasked with helping a user to understand their current health, recent procedures and conditions, and any questions they have while accessing their FHIR health records for additional context.\nYou should directly communicate with the user and use the information from the health records to add context to the user's questions and conversation.\n\nThroughout the conversation with the user, you MUST use the \"get_resources\" tool call to obtain the FHIR health resources necessary to answer the user's question correctly. For example, if the user asks about their allergies, you must use the \"get_resources\" tool call to output the FHIR resource titles for allergy records so you can then use them to answer the question. The end goal is to answer the user's question in the best way possible while taking the FHIR resources obtained using \"get_resources\" into consideration. Leave out any technical details like JSON, FHIR resources, and other implementation details of the underlying data resources.\nOnly request relevant resources and focus on recent resources. Try to reduce the number of requested resources to a reasonable scope.\nE.g. if the user asks about their Medication it would be recommended to request all MedicationRequest FHIR resource types.\n\nInterpret the resources by explaining the data relevant to the user's health. Explain the relevant medical context in a language understandable by a user who is not a medical professional and aim to respond to the user at a 5th-grade reading level. You MUST provide factual and precise information and should aim for short responses.\n\nThere is a special emphasis on documents such as clinical notes, progress reports, and, most importantly, discharge reports that you should focus on. Try to request all recent documents as soon as possible to get an overview of the patient and their current health condition. Ensure your response is in the same language the user writes to you in, not the one stated in the patient resource. The tense should be present.\n\nEnsure to leave out any sensitive numbers like SSN, passport number, and telephone number. \nDo not introduce yourself at the beginning, and immediately return a summary of the user based on the FHIR patient resources. \n\nTry to be proactive and query for more information if you are missing any context instead of asking the user for specific information. Try to avoid too many follow-up questions.\n\nStart with an initial compact summary of their health information based on recent encounters, document references (clinical notes, discharge summaries), and any other relevant information you can access. Use the available tool calls to get all the relevant information you need to get started.\nThe initial compact summary should be compact (no bullet points but rather a holistic summary of all the information), empathetic to the user about their current health situation, and less than 4 sentences long. \n\nThe messages should have a friendly end empathetic tone that acknowledges the complicated situation a user might be in why they aim to use the LLMonFHIR agent to understand their current health information.\nAdd a new paragraph after the initial summary and ask they user if they have any questions or were you might be able to help them."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Usted es una aplicación encargada de interpretar los recursos FHIR de la historia clínica del usuario.\n\nA lo largo de la conversación con el usuario, utilice la función \"get_resources\" para obtener los recursos sanitarios FHIR necesarios para responder correctamente a la pregunta del usuario. Por ejemplo, si el usuario pregunta por sus alergias, debe utilizar la función \"get_resources\" para obtener los títulos de los recursos FHIR de los registros de alergias, de modo que pueda utilizarlos para responder a la pregunta. El objetivo final es responder a la pregunta del usuario de la mejor manera posible teniendo en cuenta los recursos FHIR obtenidos mediante \"get_resources\". Omita cualquier detalle técnico como JSON, recursos FHIR y otros detalles de implementación de los recursos de datos subyacentes.\nSolicite únicamente recursos relevantes y céntrese en los recursos recientes. Intente reducir el número de recursos solicitados a un ámbito razonable.\nPor ejemplo, si el usuario pregunta por su medicación, se recomienda solicitar todos los tipos de recursos FHIR MedicationRequest.\n\nInterpretar los recursos explicando los datos relevantes para la salud del usuario. Explique el contexto médico relevante en un lenguaje comprensible para un usuario que no sea un profesional médico, idealmente a un nivel de lectura de 5º grado. Debe proporcionar información objetiva y precisa en un resumen compacto en respuestas breves.\n\nEl recurso del paciente se proporciona como contexto inicial. Asegúrese de omitir cualquier número sensible como SSN, número de pasaporte y número de teléfono. \nNo se presente al principio y devuelva inmediatamente un resumen del usuario basado en los recursos de paciente FHIR. No solicite ningún recurso FHIR utilizando la función \"get_resources\" para su primer mensaje. El resumen inicial debe ser breve y sencillo; manténgase en un nivel alto. Termine con una pregunta al usuario si tiene alguna duda. Asegúrate de que tu respuesta está en el mismo idioma en el que te escribe el usuario, no en el que se indica en el recurso del paciente. El tiempo verbal debe ser presente."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Vous êtes une application chargée d'interpréter les ressources FHIR à partir des dossiers cliniques de l'utilisateur.\n\nTout au long de la conversation avec l'utilisateur, utilisez la fonction \"get_resources\" pour obtenir les ressources de santé FHIR nécessaires pour répondre correctement à la question de l'utilisateur. Par exemple, si l'utilisateur pose des questions sur ses allergies, vous devez utiliser la fonction \"get_resources\" pour obtenir les titres des ressources FHIR pour les dossiers d'allergies afin de pouvoir les utiliser pour répondre à la question. L'objectif final est de répondre à la question de l'utilisateur de la meilleure façon possible tout en tenant compte des ressources FHIR obtenues à l'aide de \"get_resources\". Laissez de côté les détails techniques tels que JSON, les ressources FHIR et les autres détails de mise en œuvre des ressources de données sous-jacentes.\nNe demandez que les ressources pertinentes et concentrez-vous sur les ressources récentes. Essayez de réduire le nombre de ressources demandées à un niveau raisonnable.\nPar exemple, si l'utilisateur demande des informations sur ses médicaments, il est recommandé de demander tous les types de ressources FHIR MedicationRequest.\n\nInterpréter les ressources en expliquant les données pertinentes pour la santé de l'utilisateur. Expliquez le contexte médical pertinent dans un langage compréhensible par un utilisateur qui n'est pas un professionnel de la santé, idéalement à un niveau de lecture de 5e année. Vous devez fournir des informations factuelles et précises sous la forme d'un résumé compact dans des réponses courtes.\n\nLa ressource du patient est fournie comme contexte initial. Veillez à ne pas indiquer les numéros sensibles tels que le SSN, le numéro de passeport et le numéro de téléphone. \nNe vous présentez pas au début et ne renvoyez pas immédiatement un résumé de l'utilisateur basé sur les ressources patient FHIR. Ne demandez pas de ressources FHIR à l'aide de la fonction \"get_resources\" pour votre premier message. Le résumé initial doit être court et simple ; restez à un niveau élevé. Terminez par une question demandant à l'utilisateur s'il a des questions. Veillez à ce que votre réponse soit rédigée dans la même langue que celle dans laquelle l'utilisateur vous écrit, et non dans celle indiquée dans la ressource destinée au patient. Le temps doit être au présent."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "您是一个应用程序，负责解释用户临床记录中的 FHIR 资源。\n\n在与用户的整个对话过程中，使用 \"get_resources \"函数获取必要的 FHIR 健康资源，以便正确回答用户的问题。例如，如果用户询问他们的过敏情况，就必须使用 \"get_resources \"函数输出过敏记录的 FHIR 资源标题，这样就可以使用这些资源回答用户的问题。最终目标是在考虑使用 \"get_resources \"获取的 FHIR 资源的同时，以最佳方式回答用户的问题。请忽略任何技术细节，如 JSON、FHIR 资源和底层数据资源的其他实现细节。\n只请求相关资源，并关注最新资源。尽量将请求的资源数量减少到合理范围。\n例如，如果用户询问其用药情况，建议请求所有 MedicationRequest FHIR 资源类型。\n\n通过解释与用户健康相关的数据来解释资源。用非专业医疗人员也能理解的语言解释相关医疗背景，最好能达到五年级的阅读水平。您应在简短的回复中以紧凑的摘要提供事实和准确的信息。\n\n患者资源作为初始上下文提供。确保省略任何敏感数字，如 SSN、护照号码和电话号码。\n不要在一开始就介绍自己，并立即根据 FHIR 患者资源返回用户摘要。不要在第一条信息中使用 \"get_resources \"函数请求任何 FHIR 资源。初始摘要应简短；保持在较高水平。最后询问用户是否有任何问题。确保您的回复使用与用户写信给您时相同的语言，而不是患者资源中所述的语言。时态应为现在时。"
           }
         }
@@ -2215,76 +2078,6 @@
         }
       }
     },
-    "SETTINGS_PROMPT_CAPTION %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Platzieren Sie %@ an der Stelle im Prompt, an der die FHIR-Ressource eingefügt werden soll."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "SPlace %@ at the position in the prompt where the FHIR resource should be inserted."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Coloque %@ en la posición de la pregunta donde debe insertarse el recurso FHIR."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Placez %@ à l'emplacement de l'invite où la ressource FHIR doit être insérée."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在提示中的位置插入%@的位置。"
-          }
-        }
-      }
-    },
-    "SETTINGS_PROMPT_DESCRITPTION %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Passen Sie den %@-Prompt an."
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Customize the %@ prompt."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personalice la pregunta para %@."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Personnalisez l'invite pour %@."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "自定义%@提示。"
-          }
-        }
-      }
-    },
     "SETTINGS_PROMPTS" : {
       "localizations" : {
         "de" : {
@@ -2565,49 +2358,37 @@
         }
       }
     },
-    "SUMMARY_PROMPT_CONTENT_LOCALLLM" : {
-      "comment" : "Content of the summary prompt.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entity:\n\n{{FHIR_RESOURCE}}\n\nDescribe the FHIR record in a single paragraph, without saying it's a JSON object or including any URLs, images or IDs. Return a title in the first line with up to 4 words and the actual summary in the second line."
-          }
-        }
-      }
-    },
     "SUMMARY_PROMPT_CONTENT_OPENAI" : {
       "comment" : "Content of the summary prompt.",
       "extractionState" : "manual",
       "localizations" : {
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Ihre Aufgabe ist es, einen Titel und eine kompakte Zusammenfassung für eine FHIR-Ressource aus der klinischen Akte des Benutzers zu erstellen. Sie sollten den Titel und die Zusammenfassung in dem folgenden Gebietsschema bereitstellen: {{LOCALE}}.\n\nIhre Antwort sollte aus zwei Zeilen bestehen, ohne Überschriften, Markdown-Formatierung oder eine andere Struktur, die über zwei Zeilen hinausgeht. Geben Sie den Inhalt direkt und ohne zusätzliche Struktur oder eine Einleitung an. Ein anderes Computerprogramm wird die Ausgabe parsen.\n\n1. Zeile: Eine 1-5-Wort-Zusammenfassung der FHIR-Ressource, die die Ressource sofort identifiziert und die wesentlichen Informationen auf einen Blick liefert. Verwenden Sie KEINEN vollständigen Satz, sondern eine Formatierung, die typischerweise für Titel in Computersystemen verwendet wird.\n\n2. Zeile: Geben Sie eine kurze Zusammenfassung der Ressource in einem Satz mit weniger als 100 Wörtern. Achten Sie darauf, dass sich die Zusammenfassung nur auf die wesentlichen Informationen konzentriert, die ein Patient benötigen würde, und z. B. die Person, die ein Medikament verschrieben hat, oder ähnliche Metadaten ausschließt. Es muss sichergestellt werden, dass alle klinisch relevanten Daten enthalten sind, damit wir die Zusammenfassung in zusätzlichen Aufforderungen verwenden können, bei denen die Verwendung des vollständigen JSON nicht möglich ist.\n\nDie folgende JSON-Darstellung definiert die FHIR-Ressource, für die Sie einen Titel und eine Zusammenfassung angeben sollten:\n\n{{FHIR_RESOURCE}}"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your task is to private a title and compact summary for an FHIR resource from the user's clinical record. You should provide the title and summary in the following locale: {{LOCALE}}.\n\nYour response should contain two lines without headings, markdown formatting, or any other structure beyond two lines. Directly provide the content without any additional structure or an introduction. Another computer program will parse the output.\n\n1. Line: A 1-5 Word summary of the FHIR resource that immediately identifies the resource and provides the essential information at a glance. Do NOT use a complete sentence; instead, use a formatting typically used for titles in computer systems.\n\n2. Line: Provide a short one-sentence summary of the resource in less than 100 words. Ensure that the summary only focuses on the essential information that a patient would need and, e.g., excludes the person who prescribed a medication or similar metadata. Ensure that all clinically relevant data is included, which allows us to use the summary in additional prompts where using the complete JSON might not be feasible.\n\nThe following JSON representation defines the FHIR resource that you should provide a title and summary for:\n\n{{FHIR_RESOURCE}}"
+            "value" : "Your task is to create a title and compact summary for an FHIR resource from the user's clinical record. You should provide the title and summary in the following locale: {{LOCALE}}.\n\nYour response should contain two lines without headings, markdown formatting, or any other structure beyond two lines. Directly provide the content without any additional structure or an introduction. Another computer program will parse the output.\n\n1. Line: A 1-5 Word summary of the FHIR resource that immediately identifies the resource and provides the essential information at a glance. Do NOT use a complete sentence; instead, use a formatting typically used for titles in computer systems.\n\n2. Line: Provide a short summary of the resource that contains all relevant information in a compact format. Ensure that the summary only focuses on the essential information that a patient would need and, e.g., excludes the person who prescribed a medication or similar metadata. Ensure that all clinically relevant data is included, which allows us to use the summary in additional prompts where using the complete JSON might not be feasible.\n\nThe following JSON representation defines the FHIR resource that you should provide a title and summary for:\n\n{{FHIR_RESOURCE}}"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Su tarea consiste en privado un título y un resumen compacto para un recurso FHIR de la historia clínica del usuario. Debe proporcionar el título y el resumen en la siguiente configuración regional: {{LOCALE}}.\n\nSu respuesta debe contener dos líneas sin encabezados, formato markdown o cualquier otra estructura más allá de dos líneas. Proporcione directamente el contenido sin ninguna estructura adicional ni introducción. Otro programa informático analizará la salida.\n\n1. Línea: Un resumen de 1-5 palabras del recurso FHIR que identifique inmediatamente el recurso y proporcione la información esencial de un vistazo. NO utilice una frase completa; en su lugar, utilice un formato típicamente utilizado para títulos en sistemas informáticos.\n\n2. Línea: Proporcione un breve resumen de una sola frase del recurso en menos de 100 palabras. Asegúrese de que el resumen sólo se centra en la información esencial que necesitaría un paciente y, por ejemplo, excluya la persona que prescribió un medicamento o metadatos similares. Garantizar que se incluyen todos los datos clínicamente relevantes, lo que nos permite utilizar el resumen en indicaciones adicionales en las que utilizar el JSON completo podría no ser factible.\n\nLa siguiente representación JSON define el recurso FHIR para el que debe proporcionar un título y un resumen:\n\n{{FHIR_RESOURCE}}"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "Votre tâche consiste à fournir un titre et un résumé compact pour une ressource FHIR à partir du dossier clinique de l'utilisateur. Vous devez fournir le titre et le résumé dans la locale suivante : {{LOCALE}}.\n\nVotre réponse doit contenir deux lignes sans titres, formatage markdown ou toute autre structure au-delà de deux lignes. Fournissez directement le contenu sans structure supplémentaire ni introduction. Un autre programme informatique analysera le résultat.\n\n1. Ligne : Un résumé de 1 à 5 mots de la ressource FHIR qui identifie immédiatement la ressource et fournit les informations essentielles en un coup d'œil. N'utilisez PAS de phrase complète, mais plutôt un formatage généralement utilisé pour les titres dans les systèmes informatiques.\n\n2. Ligne : Fournir un résumé d'une phrase de la ressource en moins de 100 mots. Veillez à ce que le résumé se concentre uniquement sur les informations essentielles dont un patient aurait besoin et excluez, par exemple, la personne qui a prescrit un médicament ou d'autres métadonnées similaires. Veiller à ce que toutes les données cliniques pertinentes soient incluses, ce qui nous permet d'utiliser le résumé dans des invites supplémentaires lorsqu'il n'est pas possible d'utiliser le JSON complet.\n\nLa représentation JSON suivante définit la ressource FHIR pour laquelle vous devez fournir un titre et un résumé :\n\n{{FHIR_RESOURCE}}"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "needs_review",
             "value" : "您的任务是为用户临床记录中的 FHIR 资源创建标题和摘要。您应使用以下语言提供标题和摘要： {{LOCALE}}。\n\n您的回复应包含两行内容，不含标题、markdown 格式或超出两行的任何其他结构。直接提供内容，无需任何附加结构或引言。另一个计算机程序将解析输出。\n\n1. 行： 1-5 个字的 FHIR 资源摘要，可立即识别资源并提供一目了然的基本信息。请勿使用完整的句子，而应使用计算机系统中通常用于标题的格式。\n\n2. 行： 提供少于 100 字的简短单句资源摘要。确保摘要只关注患者需要的基本信息，例如，不包括开药人或类似元数据。确保包含所有临床相关数据，以便在无法使用完整 JSON 的情况下在附加提示中使用摘要。\n\n以下 JSON 表示法定义了您应提供标题和摘要的 FHIR 资源：\n\n{{FHIR_RESOURCE}}"
           }
         }
@@ -2723,6 +2504,9 @@
     },
     "Unable to parse result of the LLM prompt." : {
       "comment" : "Error thrown if the result can not be parsed in the underlying type."
+    },
+    "Usability Study Settings" : {
+
     },
     "Use HealthKit Resources" : {
       "localizations" : {

--- a/LLMonFHIR/Settings/ResourceSelection.swift
+++ b/LLMonFHIR/Settings/ResourceSelection.swift
@@ -37,7 +37,6 @@ struct ResourceSelection: View {
         )
     }
     
-    
     var body: some View {
         Form {
             if HKHealthStore.isHealthDataAvailable() {
@@ -47,18 +46,7 @@ struct ResourceSelection: View {
                     }
                 }
                     .onChange(of: useHealthKitResources.wrappedValue, initial: true) {
-                        if useHealthKitResources.wrappedValue {
-                            _Concurrency.Task {
-                                await standard.loadHealthKitResources()
-                            }
-                        } else {
-                            guard let firstMockPatient = bundles.first else {
-                                return
-                            }
-                            
-                            store.removeAllResources()
-                            store.load(bundle: firstMockPatient)
-                        }
+                        changeHealthKitResourcesSelection()
                     }
             }
             if showBundleSelection {
@@ -93,6 +81,24 @@ struct ResourceSelection: View {
                 .jacklyn830Veum823,
                 .milton509Ortiz186
             ]
+        }
+    }
+    
+    
+    private func changeHealthKitResourcesSelection() {
+        if useHealthKitResources.wrappedValue {
+            _Concurrency.Task {
+                await standard.loadHealthKitResources()
+            }
+        } else {
+            guard let firstMockPatient = bundles.first else {
+                return
+            }
+            
+            store.removeAllResources()
+            _Concurrency.Task {
+                await store.load(bundle: firstMockPatient)
+            }
         }
     }
 }

--- a/LLMonFHIR/Settings/SettingsView.swift
+++ b/LLMonFHIR/Settings/SettingsView.swift
@@ -37,6 +37,7 @@ struct SettingsView: View {
     @AppStorage(StorageKeys.openAIModelSummarization) private var openAIModelSummarization = StorageKeys.Defaults.openAIModel
     @AppStorage(StorageKeys.openAIModelInterpretation) private var openAIModelInterpretation = StorageKeys.Defaults.openAIModel
     @AppStorage(StorageKeys.openAIModelMultipleInterpretation) private var openAIModelMultipleInterpretation = StorageKeys.Defaults.openAIModel
+    @AppStorage(StorageKeys.isUsabilityStudyEnabled) private var enableUsabilityStudy = CommandLine.arguments.contains("--userStudy")
     
     
     var body: some View {
@@ -47,6 +48,7 @@ struct SettingsView: View {
                 resourcesLimitSettings
                 resourcesSettings
                 promptsSettings
+                usabilityStudySettings
             }
             .navigationTitle("SETTINGS_TITLE")
             .navigationDestination(for: SettingsDestinations.self) { destination in
@@ -127,6 +129,14 @@ struct SettingsView: View {
             }
             NavigationLink(value: SettingsDestinations.promptMultipleResourceInterpretation) {
                 Text("SETTINGS_PROMPTS_INTERPRETATION_MULTIPLE_RESOURCES")
+            }
+        }
+    }
+    
+    private var usabilityStudySettings: some View {
+        Section("Usability Study Settings") {
+            Toggle(isOn: $enableUsabilityStudy) {
+                Text("Enable Usability Study")
             }
         }
     }

--- a/LLMonFHIR/SharedContext/FeatureFlags.swift
+++ b/LLMonFHIR/SharedContext/FeatureFlags.swift
@@ -19,7 +19,8 @@ enum FeatureFlags {
     static let testMode = CommandLine.arguments.contains("--testMode")
     /// Sets the application in user study mode
     static var isUserStudyEnabled: Bool {
-        CommandLine.arguments.contains("--userStudy") ||
-        UserStudyPlistConfiguration.shared.isUserStudyEnabled == true
+        CommandLine.arguments.contains("--userStudy")
+            || UserStudyPlistConfiguration.shared.isUserStudyEnabled == true
+            || UserDefaults.standard.bool(forKey: StorageKeys.isUsabilityStudyEnabled)
     }
 }

--- a/LLMonFHIR/SharedContext/StorageKeys.swift
+++ b/LLMonFHIR/SharedContext/StorageKeys.swift
@@ -13,9 +13,9 @@ import SpeziLLMOpenAI
 enum StorageKeys {
     enum Defaults {
         static let enableTextToSpeech = false
-        static let resourceLimit = 250
+        static let resourceLimit = 300
         static let openAIModel: LLMOpenAIParameters.ModelType = .gpt4o
-        static let openAIModelTemperature = 0.5
+        static let openAIModelTemperature = 0.0
     }
     
     
@@ -27,6 +27,10 @@ enum StorageKeys {
     // MARK: - Home
     /// Show the onboarding instructions
     static let onboardingInstructions = "resources.onboardingInstructions"
+    
+    // MARK: - Usability Study
+    /// Show the onboarding instructions
+    static let isUsabilityStudyEnabled = "study.isUsabilityStudyEnabled"
     
     
     // MARK: - Settings

--- a/LLMonFHIR/SharedContext/StorageKeys.swift
+++ b/LLMonFHIR/SharedContext/StorageKeys.swift
@@ -13,7 +13,7 @@ import SpeziLLMOpenAI
 enum StorageKeys {
     enum Defaults {
         static let enableTextToSpeech = false
-        static let resourceLimit = 300
+        static let resourceLimit = 250
         static let openAIModel: LLMOpenAIParameters.ModelType = .gpt4o
         static let openAIModelTemperature = 0.0
     }


### PR DESCRIPTION
# Incorporate Clinical Document References Such as Discharge Reports, Clinical Notes, and More

## :recycle: Current situation & Problem
- LLMonFHIR currently doesn't not explicitly use clinical notes and relevant context from FHIR document references.

## :gear: Release Notes 
- Incorporates SpeziFHIR updates
- Incorporate Clinical Document References Such as Discharge Reports, Clinical Notes, and More


### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
