### PR TITLE
Improve Parsing Logic for Resource Summary

### DIFF
--- a/LLMonFHIR/FHIRSummary/FHIRResourceSummary.swift
+++ b/LLMonFHIR/FHIRSummary/FHIRResourceSummary.swift
@@ -29,43 +29,18 @@ final class FHIRResourceSummary: Sendable {
         
         
         init?(_ description: String) {
-            let lines = description
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-                .components(separatedBy: "\n")
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-                .filter { !$0.isEmpty }
+            let lines = description.components(separatedBy: "\n")
+            let nonEmptyLines = lines.filter { !$0.isEmpty }
 
-            guard !lines.isEmpty else {
+            switch nonEmptyLines.count {
+            case 0:
                 return nil
-            }
-
-            if lines.count == 1 {
-                let wordCount = lines[0]
-                    .components(separatedBy: .whitespacesAndNewlines)
-                    .filter { !$0.isEmpty }
-                    .count
-
-                if wordCount <= 4 {
-                    self.title = lines[0]
-                    self.summary = "No detailed summary available"
-                } else {
-                    let words = lines[0]
-                        .components(separatedBy: .whitespacesAndNewlines)
-                        .filter { !$0.isEmpty }
-                    self.title = words
-                        .prefix(3)
-                        .joined(separator: " ")
-                    self.summary = lines[0]
-                }
-            } else {
-                self.title = lines[0]
-                self.summary = lines
-                    .dropFirst()
-                    .joined(separator: " ")
-            }
-
-            guard !self.title.isEmpty && !self.summary.isEmpty else {
-                return nil
+            case 1:
+                title = nonEmptyLines[0]
+                summary = nonEmptyLines[0]
+            default:
+                title = nonEmptyLines[0]
+                summary = nonEmptyLines.dropFirst().joined(separator: "\n")
             }
         }
     }

--- a/LLMonFHIR/FHIRSummary/FHIRResourceSummary.swift
+++ b/LLMonFHIR/FHIRSummary/FHIRResourceSummary.swift
@@ -29,13 +29,44 @@ final class FHIRResourceSummary: Sendable {
         
         
         init?(_ description: String) {
-            let components = description.split(separator: "\n")
-            guard components.count == 2, let title = components.first, let summary = components.last else {
+            let lines = description
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .components(separatedBy: "\n")
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+
+            guard !lines.isEmpty else {
                 return nil
             }
-            
-            self.title = String(title)
-            self.summary = String(summary)
+
+            if lines.count == 1 {
+                let wordCount = lines[0]
+                    .components(separatedBy: .whitespacesAndNewlines)
+                    .filter { !$0.isEmpty }
+                    .count
+
+                if wordCount <= 4 {
+                    self.title = lines[0]
+                    self.summary = "No detailed summary available"
+                } else {
+                    let words = lines[0]
+                        .components(separatedBy: .whitespacesAndNewlines)
+                        .filter { !$0.isEmpty }
+                    self.title = words
+                        .prefix(3)
+                        .joined(separator: " ")
+                    self.summary = lines[0]
+                }
+            } else {
+                self.title = lines[0]
+                self.summary = lines
+                    .dropFirst()
+                    .joined(separator: " ")
+            }
+
+            guard !self.title.isEmpty && !self.summary.isEmpty else {
+                return nil
+            }
         }
     }
     

--- a/LLMonFHIR/FHIRSummary/FHIRResourceSummary.swift
+++ b/LLMonFHIR/FHIRSummary/FHIRResourceSummary.swift
@@ -91,7 +91,7 @@ final class FHIRResourceSummary: Sendable {
                 break
             }
 
-            try? await Task.sleep(for: .seconds(0.5))
+            try? await Task.sleep(for: .seconds(0.1))
         } while retryCount < maxRetries
 
         guard let summary = summary else {

--- a/LLMonFHIR/LLMonFHIRDelegate.swift
+++ b/LLMonFHIR/LLMonFHIRDelegate.swift
@@ -24,12 +24,16 @@ class LLMonFHIRDelegate: SpeziAppDelegate {
                 healthKit
             }
             LLMRunner {
-                LLMLocalPlatform()
-                LLMOpenAIPlatform(configuration: .init(concurrentStreams: 20))
+                LLMOpenAIPlatform(configuration: .init(concurrentStreams: 100))
             }
             FHIRInterpretationModule()
             AccessGuardModule([
-                .fixed(identifier: .userStudyIndentifier, code: "0218", codeOptions: .fourDigitNumeric, timeout: 60 * 60)
+                .fixed(
+                    identifier: .userStudyIndentifier,
+                    code: "0218",
+                    codeOptions: .fourDigitNumeric,
+                    timeout: 60 * 60
+                )
             ])
         }
     }

--- a/LLMonFHIRTests/FHIRSummary/FHIRResourceSummaryTests.swift
+++ b/LLMonFHIRTests/FHIRSummary/FHIRResourceSummaryTests.swift
@@ -1,0 +1,69 @@
+//
+// This source file is part of the Stanford LLM on FHIR project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+@testable import LLMonFHIR
+import Testing
+
+
+@Suite("FHIRResourceSummary.Summary Initializer Tests")
+struct FHIRResourceSummaryTests {
+    @Test("Summary initializer with one line input")
+    func summaryInitializerWithOneLineInput() throws {
+        let input = "This is a title"
+        let summary = FHIRResourceSummary.Summary(input)
+
+        #expect(summary?.title == "This is a title")
+        #expect(summary?.summary == "This is a title")
+    }
+
+    @Test("Summary initializer with multiline input")
+    func summaryInitializerWithMultilineInput() throws {
+        let input = "Title\nFirst line of summary\nSecond line of summary"
+        let summary = FHIRResourceSummary.Summary(input)
+
+        #expect(summary != nil)
+        #expect(summary?.title == "Title")
+        #expect(summary?.summary == "First line of summary\nSecond line of summary")
+    }
+
+    @Test("Summary initializer with empty input returns nil")
+    func summaryInitializerWithEmptyInput() throws {
+        let input = ""
+        let summary = FHIRResourceSummary.Summary(input)
+
+        #expect(summary == nil, "Summary should be nil for empty input")
+    }
+
+    @Test("Summary initializer preserves whitespace around content")
+    func summaryInitializerWithWhitespaceAroundContent() throws {
+        let input = "  Title with whitespace  \n  Summary with whitespace  "
+        let summary = FHIRResourceSummary.Summary(input)
+
+        #expect(summary?.title == "  Title with whitespace  ")
+        #expect(summary?.summary == "  Summary with whitespace  ")
+    }
+
+    @Test("Summary conforms to LosslessStringConvertible")
+    func summaryStringConversion() throws {
+        let title = "Test Title"
+        let summaryText = "This is a test summary"
+        let input = "\(title)\n\(summaryText)"
+        let summary = FHIRResourceSummary.Summary(input)
+
+        #expect(summary?.description == "\(title)\n\(summaryText)")
+    }
+
+    @Test("Summary correctly filters empty lines")
+    func summaryEmptyLineFiltering() throws {
+        let input = "Title\n\nFirst line\n\nSecond line\n\n"
+        let summary = FHIRResourceSummary.Summary(input)
+
+        #expect(summary?.title == "Title")
+        #expect(summary?.summary == "First line\nSecond line")
+    }
+}


### PR DESCRIPTION
# Improve Parsing Logic for Resource Summary

## :recycle: Current situation & Problem
https://github.com/StanfordBDHG/LLMonFHIR/issues/76#issuecomment-2716922417


## :gear: Release Notes
- 0 lines: Returns nil (unchanged)
- 1 line: Used for both title and summary
- 2+ lines: First line = title, rest = summary
- Increase the number of concurrent streams from 20 to 100 to speed up response generation

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
