### PR TITLE
Collapse Resource Categories by Default

### DIFF
--- a/LLMonFHIR/FHIR Views/FHIRResourcesView.swift
+++ b/LLMonFHIR/FHIR Views/FHIRResourcesView.swift
@@ -141,6 +141,7 @@ struct FHIRResourcesView<ContentView: View, ActionView: View>: View {
                 resourcesList(resources: resources, showAll: showAll)
             } header: {
                 sectionHeaderButton(sectionName: sectionName, resources: resources, showAll: showAll)
+                    .textCase(nil)
             }
             .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
         )

--- a/LLMonFHIR/Resources/Localizable.xcstrings
+++ b/LLMonFHIR/Resources/Localizable.xcstrings
@@ -4,6 +4,9 @@
     "%.2f" : {
 
     },
+    "%lld" : {
+
+    },
     "A team member will be with you soon. During this study, you’ll complete a survey about your experiences navigating the healthcare system and have the opportunity to ask the chat questions about your health." : {
 
     },


### PR DESCRIPTION
# Collapse Resource Categories by Default

#73 

## :recycle: Current situation & Problem
When working with synthetic data, we often encounter extensive data sets that require significant scrolling. This creates an inefficient user experience when navigating through large resource category lists.


## :gear: Release Notes
Resource category lists are now collapsed by default. Users can expand specific sections as needed.

<img width="400" alt="Simulator Screenshot - iPhone 16 Plus - 2025-03-12 at 20 54 58" src="https://github.com/user-attachments/assets/d7785f46-af18-4eef-a3f9-9419f70b86f0" />

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
