### PR TITLE
Refactor FHIR Multiple Resource Interpreter and Chat

### DIFF
--- a/LLMonFHIR.xcodeproj/project.pbxproj
+++ b/LLMonFHIR.xcodeproj/project.pbxproj
@@ -984,7 +984,7 @@
 			repositoryURL = "https://github.com/StanfordSpezi/SpeziFHIR";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.7.5;
+				minimumVersion = 0.7.6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LLMonFHIR.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "01cef502d89e28109d2b3b51a4a7530b053fc8c98dd9ceb3b6a2a7750e4ba177",
+  "originHash" : "065a78a0fbd76259f6e2dfbe31b9495b32f90d0df81787c26e41278e93557c5c",
   "pins" : [
     {
       "identity" : "collectionconcurrencykit",
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/StanfordSpezi/SpeziFHIR",
       "state" : {
-        "revision" : "bb7f7b5ecfb92b331c9eb8a85e1dcca2cb0990e3",
-        "version" : "0.7.5"
+        "revision" : "d5622db006da1c6d460e47074371222d653213fc",
+        "version" : "0.7.6"
       }
     },
     {

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
@@ -103,7 +103,11 @@ final class FHIRMultipleResourceInterpreter {
     func generateAssistantResponse() {
         currentGenerationTask?.cancel()
 
-        currentGenerationTask = Task {
+        currentGenerationTask = Task { [weak self] in
+            guard let self else {
+                return
+            }
+
             defer {
                 currentGenerationTask = nil
             }

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/FHIRMultipleResourceInterpreter.swift
@@ -45,21 +45,6 @@ final class FHIRMultipleResourceInterpreter {
     /// user inputs, and assistant responses. Changes to this property will be reflected in the UI.
     private(set) var llmSession: any LLMSession
 
-    var shouldGenerateResponse: Bool {
-        if llmSession.state == .generating {
-            return false
-        }
-
-        // Check if the last message is from a user (needs a response)
-        let lastMessageIsUser = llmSession.context.last?.role == .user
-
-        // Check if there are no assistant messages yet (initial prompt needs a response)
-        let noAssistantMessages = !llmSession.context.contains(where: { $0.role == .assistant() })
-
-        // Generate if last message is from user or if there are no assistant messages yet
-        return (lastMessageIsUser || noAssistantMessages)
-    }
-
 
     /// Initializes a new FHIR resource interpreter with the provided dependencies.
     ///

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourceChatViewModel.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourceChatViewModel.swift
@@ -1,0 +1,105 @@
+//
+// This source file is part of the Stanford Spezi project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SpeziChat
+import SpeziLLM
+import SwiftUI
+
+/// View model for the MultipleResourcesChatView.
+///
+/// This view model coordinates between the UI and the FHIRMultipleResourceInterpreter.
+/// It provides UI-specific computed properties and methods while delegating
+/// LLM operations and persistence to the underlying interpreter.
+@MainActor
+final class MultipleResourcesChatViewModel: ObservableObject {
+    private let interpreter: FHIRMultipleResourceInterpreter
+
+    /// Two-way binding to the text-to-speech setting controlled by the view
+    @Binding var textToSpeech: Bool
+
+    /// Indicates if the LLM is currently processing or generating a response
+    /// This property directly reflects the LLM session's state
+    var isProcessing: Bool {
+        llmSession.state.representation == .processing
+    }
+
+    /// The title displayed in the navigation bar
+    let navigationTitle: String
+
+    /// Provides a binding to the chat messages for use in SwiftUI views
+    ///
+    /// This binding allows the ChatView component to both display messages
+    /// and add new user messages to the conversation.
+    var chatBinding: Binding<Chat> {
+       Binding(
+           get: { [weak self] in
+               self?.interpreter.llmSession.context.chat ?? []
+           },
+           set: { [weak self] newChat in
+               self?.interpreter.llmSession.context.chat = newChat
+           }
+       )
+    }
+
+    /// Direct access to the current LLM session for observing state changes
+    var llmSession: LLMSession {
+        interpreter.llmSession
+    }
+
+    private var shouldGenerateResponse: Bool {
+        if llmSession.state == .generating || isProcessing {
+            return false
+        }
+
+        // Check if the last message is from a user (needs a response)
+        let lastMessageIsUser = interpreter.llmSession.context.last?.role == .user
+
+        // Check if there are no assistant messages yet (initial prompt needs a response)
+        let noAssistantMessages = !interpreter.llmSession.context.contains(where: { $0.role == .assistant() })
+
+        // Generate if last message is from user or if there are no assistant messages yet
+        return (lastMessageIsUser || noAssistantMessages)
+    }
+
+    /// Creates a view model with the specified interpreter and settings.
+    ///
+    /// - Parameters:
+    ///   - interpreter: The FHIR resource interpreter to use for LLM operations
+    ///   - navigationTitle: The title to display in the navigation bar
+    ///   - textToSpeech: Binding to the text-to-speech setting
+    init(interpreter: FHIRMultipleResourceInterpreter, navigationTitle: String, textToSpeech: Binding<Bool>) {
+        self.interpreter = interpreter
+        self.navigationTitle = navigationTitle
+        self._textToSpeech = textToSpeech
+    }
+
+    /// Starts a new conversation by clearing all user and assistant messages
+    ///
+    /// This preserves system messages but removes all conversation history,
+    /// providing the user with a fresh chat while maintaining the interpreter context.
+    func startNewConversation() {
+        interpreter.startNewConversation()
+    }
+
+    /// Cancels any ongoing operations and dismisses the current view
+    ///
+    /// - Parameter dismiss: The dismiss action from the environment to close the view
+    func dismiss(_ dismiss: DismissAction) {
+        interpreter.cancel()
+        dismiss()
+    }
+
+    /// Generates an assistant response  for the current context
+    func generateAssistantResponse() {
+        guard shouldGenerateResponse else {
+            return
+        }
+        interpreter.generateAssistantResponse()
+    }
+}

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourceChatViewModel.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourceChatViewModel.swift
@@ -26,7 +26,7 @@ final class MultipleResourcesChatViewModel: ObservableObject {
     }
 
     /// Two-way binding to the text-to-speech setting controlled by the view
-    @Binding var textToSpeech: Bool
+    @AppStorage(StorageKeys.enableTextToSpeech) var textToSpeech = StorageKeys.currentEnableTextToSpeech
 
     /// Indicates if the LLM is currently processing or generating a response
     /// This property directly reflects the LLM session's state
@@ -78,11 +78,9 @@ final class MultipleResourcesChatViewModel: ObservableObject {
     /// - Parameters:
     ///   - interpreter: The FHIR resource interpreter to use for LLM operations
     ///   - navigationTitle: The title to display in the navigation bar
-    ///   - textToSpeech: Binding to the text-to-speech setting
-    init(interpreter: FHIRMultipleResourceInterpreter, navigationTitle: String, textToSpeech: Binding<Bool>) {
+    init(interpreter: FHIRMultipleResourceInterpreter, navigationTitle: String) {
         self.interpreter = interpreter
         self.navigationTitle = navigationTitle
-        self._textToSpeech = textToSpeech
     }
 
     /// Starts a new conversation by clearing all user and assistant messages

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourceChatViewModel.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourceChatViewModel.swift
@@ -17,16 +17,14 @@ import SwiftUI
 /// It provides UI-specific computed properties and methods while delegating
 /// LLM operations and persistence to the underlying interpreter.
 @MainActor
-final class MultipleResourcesChatViewModel: ObservableObject {
+@Observable
+final class MultipleResourcesChatViewModel {
     private let interpreter: FHIRMultipleResourceInterpreter
 
     /// Direct access to the current LLM session for observing state changes
     var llmSession: LLMSession {
         interpreter.llmSession
     }
-
-    /// Two-way binding to the text-to-speech setting controlled by the view
-    @AppStorage(StorageKeys.enableTextToSpeech) var textToSpeech = StorageKeys.currentEnableTextToSpeech
 
     /// Indicates if the LLM is currently processing or generating a response
     /// This property directly reflects the LLM session's state

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourceChatViewModel.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourceChatViewModel.swift
@@ -20,6 +20,11 @@ import SwiftUI
 final class MultipleResourcesChatViewModel: ObservableObject {
     private let interpreter: FHIRMultipleResourceInterpreter
 
+    /// Direct access to the current LLM session for observing state changes
+    var llmSession: LLMSession {
+        interpreter.llmSession
+    }
+
     /// Two-way binding to the text-to-speech setting controlled by the view
     @Binding var textToSpeech: Bool
 
@@ -27,6 +32,12 @@ final class MultipleResourcesChatViewModel: ObservableObject {
     /// This property directly reflects the LLM session's state
     var isProcessing: Bool {
         llmSession.state.representation == .processing
+    }
+
+    /// Determines whether to display a typing indicator in the chat interface.
+    var showTypingIndicator: Bool {
+        let role = llmSession.context.last?.role
+        return role == .user || role == .system
     }
 
     /// The title displayed in the navigation bar
@@ -45,11 +56,6 @@ final class MultipleResourcesChatViewModel: ObservableObject {
                self?.interpreter.llmSession.context.chat = newChat
            }
        )
-    }
-
-    /// Direct access to the current LLM session for observing state changes
-    var llmSession: LLMSession {
-        interpreter.llmSession
     }
 
     private var shouldGenerateResponse: Bool {

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
@@ -16,8 +16,11 @@ import SwiftUI
 
 
 struct MultipleResourcesChatView: View {
-    @StateObject private var viewModel: MultipleResourcesChatViewModel
     @Environment(\.dismiss) private var dismiss
+
+    @State private var viewModel: MultipleResourcesChatViewModel
+
+    @AppStorage(StorageKeys.enableTextToSpeech) private var textToSpeech = StorageKeys.currentEnableTextToSpeech
 
 
     var body: some View {
@@ -37,8 +40,8 @@ struct MultipleResourcesChatView: View {
             exportFormat: .text,
             messagePendingAnimation: .manual(shouldDisplay: viewModel.showTypingIndicator)
         )
-            .speak(viewModel.llmSession.context.chat, muted: !viewModel.textToSpeech)
-            .speechToolbarButton(muted: !viewModel.$textToSpeech)
+            .speak(viewModel.llmSession.context.chat, muted: !textToSpeech)
+            .speechToolbarButton(muted: !$textToSpeech)
             .viewStateAlert(state: viewModel.llmSession.state)
             .onChange(of: viewModel.llmSession.context, initial: true) {
                 viewModel.generateAssistantResponse()
@@ -76,11 +79,9 @@ struct MultipleResourcesChatView: View {
     ///   - navigationTitle: The title to display in the navigation bar
     ///   - textToSpeech: A binding to control whether spoken feedback is enabled
     init(interpreter: FHIRMultipleResourceInterpreter, navigationTitle: String) {
-        self._viewModel = StateObject(
-            wrappedValue: MultipleResourcesChatViewModel(
-                interpreter: interpreter,
-                navigationTitle: navigationTitle
-            )
+        viewModel = MultipleResourcesChatViewModel(
+            interpreter: interpreter,
+            navigationTitle: navigationTitle
         )
     }
 }

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
@@ -75,12 +75,11 @@ struct MultipleResourcesChatView: View {
     ///   - interpreter: The FHIR resource interpreter that manages the LLM session and healthcare data
     ///   - navigationTitle: The title to display in the navigation bar
     ///   - textToSpeech: A binding to control whether spoken feedback is enabled
-    init(interpreter: FHIRMultipleResourceInterpreter, navigationTitle: String, textToSpeech: Binding<Bool>) {
+    init(interpreter: FHIRMultipleResourceInterpreter, navigationTitle: String) {
         self._viewModel = StateObject(
             wrappedValue: MultipleResourcesChatViewModel(
                 interpreter: interpreter,
-                navigationTitle: navigationTitle,
-                textToSpeech: textToSpeech
+                navigationTitle: navigationTitle
             )
         )
     }

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
@@ -16,85 +16,72 @@ import SwiftUI
 
 
 struct MultipleResourcesChatView: View {
-    @Environment(FHIRMultipleResourceInterpreter.self) private var interpreter
+    @StateObject private var viewModel: MultipleResourcesChatViewModel
     @Environment(\.dismiss) private var dismiss
-    
-    @Binding private var textToSpeech: Bool
-    private let navigationTitle: Text
-    
-    
+
+
     var body: some View {
         NavigationStack {
             chatView
-                .navigationTitle(navigationTitle)
+                .navigationTitle(viewModel.navigationTitle)
                 .toolbar { toolbarContent }
-                .task { await interpreter.prepareLLM() }
         }
         .interactiveDismissDisabled()
     }
-    
-    
-    @MainActor @ViewBuilder private var chatView: some View {
+
+
+    @ViewBuilder private var chatView: some View {
         ChatView(
-            Binding(
-                get: { interpreter.llm.context.chat },
-                set: { interpreter.llm.context.chat = $0 }
-            ),
-            disableInput: interpreter.llm.state.representation == .processing,
+            viewModel.chatBinding,
+            disableInput: viewModel.isProcessing,
             exportFormat: .text,
-            messagePendingAnimation: .manual(shouldDisplay: interpreter.viewState == .processing)
+            messagePendingAnimation: .manual(shouldDisplay: viewModel.isProcessing)
         )
-            .speak(interpreter.llm.context.chat, muted: !textToSpeech)
-            .speechToolbarButton(muted: !$textToSpeech)
-            .viewStateAlert(state: interpreter.llm.state)
-            .onChange(of: interpreter.llm.context, initial: true) {
-                if interpreter.llm.state != .generating && interpreter.llm.context.chat.last?.role == .user {
-                    interpreter.queryLLM()
-                }
-            }
-            .onAppear {
-                guard !interpreter.llm.context.chat.contains(where: { $0.role == .user }) else {
-                    return
-                }
-                interpreter.viewState = .processing
-                interpreter.queryLLM()
+            .speak(viewModel.llmSession.context.chat, muted: !viewModel.textToSpeech)
+            .speechToolbarButton(muted: !viewModel.$textToSpeech)
+            .viewStateAlert(state: viewModel.llmSession.state)
+            .onChange(of: viewModel.llmSession.context, initial: true) {
+                viewModel.generateAssistantResponse()
             }
     }
-    
+
     @MainActor @ToolbarContentBuilder private var toolbarContent: some ToolbarContent {
-        let isProcessing = interpreter.llm.state.representation == .processing
         ToolbarItem(placement: .cancellationAction) {
             Button("Close") {
-                interpreter.llm.cancel()
-                dismiss()
+                viewModel.dismiss(dismiss)
             }
         }
         ToolbarItem(placement: .primaryAction) {
             Button(
                 action: {
-                    interpreter.resetChat()
-                    interpreter.queryLLM()
+                    viewModel.startNewConversation()
                 },
                 label: {
                     Image(systemName: "trash")
                         .accessibilityLabel(Text("Reset Chat"))
                 }
             )
-            .disabled(isProcessing)
+            .disabled(viewModel.isProcessing)
         }
     }
-    
-    
-    /// Creates a ``MultipleResourcesChatView`` displaying a Spezi `Chat` with all available FHIR resources via a Spezi LLM..
+
+
+    /// Creates a ``MultipleResourcesChatView`` that displays a chat interface for interacting with FHIR resources.
+    ///
+    /// This initializer sets up the view with the provided interpreter, navigation title, and text-to-speech setting.
+    /// It creates a view model that coordinates between the UI and the FHIR interpreter.
     ///
     /// - Parameters:
-    ///    - navigationTitle: The localized title displayed for purposes of navigation.
-    ///    - textToSpeech: Indicates if the output of the LLM is converted to speech and outputted to the user.
-    init(
-        navigationTitle: LocalizedStringResource,
-        textToSpeech: Binding<Bool>
-    ) {
-        self.navigationTitle = Text(navigationTitle)
-        self._textToSpeech = textToSpeech
+    ///   - interpreter: The FHIR resource interpreter that manages the LLM session and healthcare data
+    ///   - navigationTitle: The title to display in the navigation bar
+    ///   - textToSpeech: A binding to control whether spoken feedback is enabled
+    init(interpreter: FHIRMultipleResourceInterpreter, navigationTitle: String, textToSpeech: Binding<Bool>) {
+        self._viewModel = StateObject(
+            wrappedValue: MultipleResourcesChatViewModel(
+                interpreter: interpreter,
+                navigationTitle: navigationTitle,
+                textToSpeech: textToSpeech
+            )
+        )
     }
 }

--- a/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/MultipleResources/MultipleResourcesChatView.swift
@@ -35,7 +35,7 @@ struct MultipleResourcesChatView: View {
             viewModel.chatBinding,
             disableInput: viewModel.isProcessing,
             exportFormat: .text,
-            messagePendingAnimation: .manual(shouldDisplay: viewModel.isProcessing)
+            messagePendingAnimation: .manual(shouldDisplay: viewModel.showTypingIndicator)
         )
             .speak(viewModel.llmSession.context.chat, muted: !viewModel.textToSpeech)
             .speechToolbarButton(muted: !viewModel.$textToSpeech)

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatToolbar.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatToolbar.swift
@@ -1,0 +1,59 @@
+//
+// This source file is part of the Stanford Spezi project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+
+
+struct UserStudyChatToolbar: ToolbarContent {
+    @ObservedObject var viewModel: UserStudyChatViewModel
+    let isInputDisabled: Bool
+    let onDismiss: () -> Void
+
+
+    var body: some ToolbarContent {
+        ToolbarItem(placement: .cancellationAction) {
+            dismissButton
+        }
+
+        ToolbarItem(placement: .primaryAction) {
+            if viewModel.navigationState != .completed {
+                navigationButton
+            }
+        }
+    }
+
+
+    private var dismissButton: some View {
+        Button(action: { viewModel.isDismissDialogPresented = true }) {
+            Image(systemName: "xmark")
+                .accessibilityLabel("Dismiss")
+        }
+        .confirmationDialog(
+            "Going back will reset your chat history.",
+            isPresented: $viewModel.isDismissDialogPresented,
+            titleVisibility: .visible,
+            actions: {
+                Button("Yes", role: .destructive, action: onDismiss)
+                Button("No", role: .cancel) {}
+            },
+            message: {
+                Text("Do you want to continue?")
+            }
+        )
+    }
+
+    private var navigationButton: some View {
+        Button {
+            viewModel.isSurveyViewPresented = true
+        } label: {
+            Image(systemName: "arrow.forward.circle")
+                .accessibilityLabel("Next Task")
+        }
+        .disabled(isInputDisabled)
+    }
+}

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatToolbar.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatToolbar.swift
@@ -10,7 +10,8 @@ import SwiftUI
 
 
 struct UserStudyChatToolbar: ToolbarContent {
-    @ObservedObject var viewModel: UserStudyChatViewModel
+    @State private(set) var viewModel: UserStudyChatViewModel
+
     let isInputDisabled: Bool
     let onDismiss: () -> Void
 

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatView.swift
@@ -11,7 +11,8 @@ import SwiftUI
 
 struct UserStudyChatView: View {
     @Environment(\.dismiss) private var dismiss
-    @StateObject private var viewModel: UserStudyChatViewModel
+
+    @State private var viewModel: UserStudyChatViewModel
 
 
     var body: some View {
@@ -58,11 +59,9 @@ struct UserStudyChatView: View {
     ///
     /// - Parameter survey: The survey configuration that defines the study's tasks and structure
     init(survey: Survey, interpreter: FHIRMultipleResourceInterpreter) {
-        _viewModel = StateObject(
-            wrappedValue: UserStudyChatViewModel(
-                survey: survey,
-                interpreter: interpreter
-            )
+        viewModel = UserStudyChatViewModel(
+            survey: survey,
+            interpreter: interpreter
         )
     }
 

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatView.swift
@@ -7,204 +7,24 @@
 //
 
 import SpeziChat
-import SpeziFHIR
-import SpeziLLM
-import SpeziLLMOpenAI
-import SpeziSpeechSynthesizer
-import SpeziViews
 import SwiftUI
 
-
-// MARK: - View Model
-
-/// Represents the state for a user study chat session
-@MainActor
-final class UserStudyViewModel: ObservableObject {
-    /// The current state of the survey navigation
-    enum NavigationState: Equatable {
-        case introduction
-        case task(number: Int, total: Int)
-        case completed
-
-        var title: String {
-            switch self {
-            case .introduction:
-                return "Introduction"
-            case let .task(number, total):
-                return "Task \(number) of \(total)"
-            case .completed:
-                return "Study Completed"
-            }
-        }
-    }
-
-    /// The current navigation state of the study
-    @Published private(set) var navigationState: NavigationState = .introduction
-
-    /// Indicates whether the survey portion has been started
-    @Published private(set) var isSurveyStarted = false
-
-    /// Controls the visibility of the survey view
-    @Published var isSurveyViewPresented = false
-
-    /// Controls the visibility of the dismiss confirmation dialog
-    @Published var isDismissDialogPresented = false
-
-    private let survey: Survey
-    private var currentTaskNumber: Int = 0 {
-        didSet {
-            updateNavigationState()
-        }
-    }
-
-
-    /// Creates a new view model for managing a user study chat session
-    /// - Parameter survey: The survey configuration to use for this study
-    init(survey: Survey) {
-        self.survey = survey
-    }
-
-
-    /// Handles the submission of survey answers for the current task
-    /// - Parameter answers: Array of answers provided by the user
-    /// - Throws: An error if the submission fails
-    func submitSurveyAnswers(_ answers: [Answer]) throws {
-        for (index, answer) in answers.enumerated() {
-            try survey.submitAnswer(answer, forTaskId: currentTaskNumber, questionIndex: index)
-        }
-
-        advanceToNextTask()
-    }
-
-    /// Resets the study to its initial state
-    func resetStudy() {
-        survey.resetAllAnswers()
-        currentTaskNumber = 0
-        isSurveyStarted = false
-        updateNavigationState()
-    }
-
-    /// Starts the survey portion of the study
-    func startSurvey() {
-        if isSurveyStarted {
-            return
-        }
-        isSurveyStarted = true
-        currentTaskNumber = 1
-    }
-
-    /// Generates a formatted string for the completed study
-    /// - Returns: A formatted string containing the study results
-    func generateReport() -> String {
-        survey.generateReport()
-    }
-
-    /// Returns the current task if one is active
-    /// - Returns: The current survey task, if available
-    func getCurrentTask() -> SurveyTask? {
-        survey.tasks.first { $0.id == currentTaskNumber }
-    }
-
-    private func advanceToNextTask() {
-        if currentTaskNumber < survey.tasks.count {
-            currentTaskNumber += 1
-        } else {
-            navigationState = .completed
-        }
-    }
-
-    private func updateNavigationState() {
-        navigationState = currentTaskNumber == 0
-            ? .introduction
-            : currentTaskNumber <= survey.tasks.count
-                ? .task(number: currentTaskNumber, total: survey.tasks.count)
-                : .completed
-    }
-}
-
-
-// MARK: - Toolbar
-
-/// Represents the toolbar content for the user study chat interface
-struct ChatToolbar: ToolbarContent {
-    @ObservedObject var viewModel: UserStudyViewModel
-    let isInputDisabled: Bool
-    let onDismiss: () -> Void
-
-
-    var body: some ToolbarContent {
-        ToolbarItem(placement: .cancellationAction) {
-            dismissButton
-        }
-
-        ToolbarItem(placement: .primaryAction) {
-            if viewModel.navigationState != .completed {
-                navigationButton
-            }
-        }
-    }
-
-
-    private var dismissButton: some View {
-        Button(action: { viewModel.isDismissDialogPresented = true }) {
-            Image(systemName: "xmark")
-                .accessibilityLabel("Dismiss")
-        }
-        .confirmationDialog(
-            "Going back will reset your chat history.",
-            isPresented: $viewModel.isDismissDialogPresented,
-            titleVisibility: .visible,
-            actions: {
-                Button("Yes", role: .destructive, action: onDismiss)
-                Button("No", role: .cancel) {}
-            },
-            message: {
-                Text("Do you want to continue?")
-            }
-        )
-    }
-
-    private var navigationButton: some View {
-        Button {
-            viewModel.isSurveyViewPresented = true
-        } label: {
-            Image(systemName: "arrow.forward.circle")
-                .accessibilityLabel("Next Task")
-        }
-        .disabled(isInputDisabled)
-    }
-}
-
-
-// MARK: - Main View
-
-/// The main view for conducting a user study chat session
 struct UserStudyChatView: View {
-    @Environment(FHIRMultipleResourceInterpreter.self) private var interpreter
     @Environment(\.dismiss) private var dismiss
-    @StateObject private var viewModel: UserStudyViewModel
+    @StateObject private var viewModel: UserStudyChatViewModel
 
-    private var isInputDisabled: Bool {
-        interpreter.llm.state.representation == .processing
-    }
-    
-    private var noUserMessages: Bool {
-        !interpreter.llm.context.chat.contains(where: { $0.role == .user })
-    }
-    
-    private var noAssistantMessages: Bool {
-        !interpreter.llm.context.chat.contains(where: { $0.role == .assistant })
-    }
 
     var body: some View {
         NavigationStack {
             chatContent
                 .navigationTitle(viewModel.navigationState.title)
                 .toolbar {
-                    ChatToolbar(
+                    UserStudyChatToolbar(
                         viewModel: viewModel,
-                        isInputDisabled: isInputDisabled,
-                        onDismiss: handleDismiss
+                        isInputDisabled: viewModel.isProcessing,
+                        onDismiss: {
+                            viewModel.handleDismiss(dismiss: dismiss)
+                        }
                     )
                 }
                 .onAppear(perform: handleAppear)
@@ -219,44 +39,33 @@ struct UserStudyChatView: View {
 
     @ViewBuilder private var chatContent: some View {
         ChatView(
-            Binding(
-                get: {
-                    var chat = interpreter.llm.context.chat
-                    if viewModel.navigationState == .completed {
-                        let surveyReport = viewModel.generateReport()
-                        chat.append(ChatEntity(role: .hidden(type: .init(name: "SURVEY_REPORT")), content: surveyReport))
-                    }
-                    return chat
-                },
-                set: { interpreter.llm.context.chat = $0 }
-            ),
-            disableInput: isInputDisabled,
+            viewModel.chatBinding,
+            disableInput: viewModel.isProcessing,
             speechToText: false,
             exportFormat: viewModel.navigationState == .completed ? .text : nil,
-            messagePendingAnimation: .manual(shouldDisplay: interpreter.viewState == .processing || noAssistantMessages)
+            messagePendingAnimation: .manual(shouldDisplay: viewModel.isProcessing)
         )
-            .viewStateAlert(state: interpreter.llm.state)
-            .onChange(of: interpreter.llm.context, initial: true) {
-                if interpreter.llm.state != .generating && interpreter.llm.context.chat.last?.role == .user {
-                    interpreter.queryLLM()
-                }
-            }
-            .onAppear {
-                guard noUserMessages else {
-                    return
-                }
-                interpreter.resetChat()
-                interpreter.queryLLM()
+            .viewStateAlert(state: viewModel.llmSession.state)
+            .onChange(of: viewModel.llmSession.context, initial: true) {
+                viewModel.generateAssistantResponse()
             }
     }
-
 
     /// Creates a new user study chat view
+    ///
+    /// This initializer sets up a view for conducting a structured study with
+    /// chat-based interactions and survey tasks.
+    ///
     /// - Parameter survey: The survey configuration that defines the study's tasks and structure
-    init(survey: Survey) {
-        _viewModel = StateObject(wrappedValue: UserStudyViewModel(survey: survey))
+    init(survey: Survey, interpreter: FHIRMultipleResourceInterpreter) {
+        _viewModel = StateObject(
+            wrappedValue: UserStudyChatViewModel(
+                survey: survey,
+                interpreter: interpreter
+            )
+        )
     }
-    
+
 
     @ViewBuilder
     private func surveySheet() -> some View {
@@ -277,12 +86,6 @@ struct UserStudyChatView: View {
 
     private func handleAppear() {
         viewModel.startSurvey()
-        interpreter.resetChat()
-    }
-
-    private func handleDismiss() {
-        viewModel.resetStudy()
-        interpreter.resetChat()
-        dismiss()
+        viewModel.startNewConversation()
     }
 }

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatView.swift
@@ -43,7 +43,7 @@ struct UserStudyChatView: View {
             disableInput: viewModel.isProcessing,
             speechToText: false,
             exportFormat: viewModel.navigationState == .completed ? .text : nil,
-            messagePendingAnimation: .manual(shouldDisplay: viewModel.isProcessing)
+            messagePendingAnimation: .manual(shouldDisplay: viewModel.showTypingIndicator)
         )
             .viewStateAlert(state: viewModel.llmSession.state)
             .onChange(of: viewModel.llmSession.context, initial: true) {

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatView.swift
@@ -85,6 +85,5 @@ struct UserStudyChatView: View {
 
     private func handleAppear() {
         viewModel.startSurvey()
-        viewModel.startNewConversation()
     }
 }

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatViewModel.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatViewModel.swift
@@ -1,0 +1,219 @@
+//
+// This source file is part of the Stanford Spezi project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SpeziChat
+import SpeziLLM
+import SwiftUI
+
+
+/// View model for the UserStudyChatView.
+///
+/// This view model coordinates between the UI and the FHIRMultipleResourceInterpreter.
+/// It provides UI-specific computed properties and methods while delegating
+/// LLM operations and persistence to the underlying interpreter.
+@MainActor
+final class UserStudyChatViewModel: ObservableObject {
+    // MARK: - Navigation State
+
+    /// The current state of the survey navigation
+    enum NavigationState: Equatable {
+        case introduction
+        case task(number: Int, total: Int)
+        case completed
+
+        /// The title to display in the navigation bar based on current state
+        var title: String {
+            switch self {
+            case .introduction:
+                return "Introduction"
+            case let .task(number, total):
+                return "Task \(number) of \(total)"
+            case .completed:
+                return "Study Completed"
+            }
+        }
+    }
+
+    /// The current navigation state of the study
+    @Published private(set) var navigationState: NavigationState = .introduction
+
+    /// Indicates whether the survey portion has been started
+    @Published private(set) var isSurveyStarted = false
+
+    /// Controls the visibility of the survey view
+    @Published var isSurveyViewPresented = false
+
+    /// Controls the visibility of the dismiss confirmation dialog
+    @Published var isDismissDialogPresented = false
+
+    private let survey: Survey
+    private let interpreter: FHIRMultipleResourceInterpreter
+
+    private var currentTaskNumber: Int = 0 {
+        didSet {
+            updateNavigationState()
+        }
+    }
+
+    /// Indicates if the LLM is currently processing or generating a response
+    /// This property directly reflects the LLM session's state
+    var isProcessing: Bool {
+        llmSession.state.representation == .processing
+    }
+
+    /// Direct access to the current LLM session for observing state changes
+    var llmSession: LLMSession {
+        interpreter.llmSession
+    }
+
+    /// Provides a binding to the chat messages for use in SwiftUI views
+    ///
+    /// This binding allows the ChatView component to both display messages
+    /// and add new user messages to the conversation. It also adds survey
+    /// report data when the survey is completed.
+    var chatBinding: Binding<Chat> {
+        Binding(
+            get: { [weak self] in
+                guard let self = self else {
+                    return []
+                }
+
+                var chat = self.interpreter.llmSession.context.chat
+                if self.navigationState == .completed {
+                    let surveyReport = self.generateReport()
+                    chat.append(ChatEntity(role: .hidden(type: .init(name: "SURVEY_REPORT")), content: surveyReport))
+                }
+                return chat
+            },
+            set: { [weak self] newChat in
+                self?.interpreter.llmSession.context.chat = newChat
+            }
+        )
+    }
+
+    private var shouldGenerateResponse: Bool {
+        if llmSession.state == .generating || isProcessing {
+            return false
+        }
+
+        // Check if the last message is from a user (needs a response)
+        let lastMessageIsUser = interpreter.llmSession.context.last?.role == .user
+
+        // Check if there are no assistant messages yet (initial prompt needs a response)
+        let noAssistantMessages = !interpreter.llmSession.context.contains(where: { $0.role == .assistant() })
+
+        // Generate if last message is from user or if there are no assistant messages yet
+        return (lastMessageIsUser || noAssistantMessages)
+    }
+
+
+    /// Creates a new view model for managing a user study chat session
+    ///
+    /// - Parameters:
+    ///   - survey: The survey configuration to use for this study
+    ///   - interpreter: The FHIR interpreter to use for chat functionality
+    init(survey: Survey, interpreter: FHIRMultipleResourceInterpreter) {
+        self.survey = survey
+        self.interpreter = interpreter
+    }
+
+
+    /// Starts a new conversation by clearing all user and assistant messages
+    ///
+    /// This preserves system messages but removes all conversation history,
+    /// providing the user with a fresh chat while maintaining the interpreter context.
+    func startNewConversation() {
+        interpreter.startNewConversation()
+    }
+
+    /// Generates an assistant response if appropriate for the current context
+    ///
+    /// This method checks if a response is needed and if so, delegates
+    /// to the interpreter to generate the actual response.
+    func generateAssistantResponse() {
+        guard shouldGenerateResponse else {
+            return
+        }
+        interpreter.generateAssistantResponse()
+    }
+
+    /// Cancels any ongoing operations and dismisses the current view
+    ///
+    /// - Parameter dismiss: The dismiss action from the environment to close the view
+    func handleDismiss(dismiss: DismissAction) {
+        interpreter.cancel()
+        resetStudy()
+        dismiss()
+    }
+
+    // MARK: - Survey Methods
+
+    /// Handles the submission of survey answers for the current task
+    ///
+    /// This method processes the user's answers and advances to the next task
+    /// in the survey sequence.
+    ///
+    /// - Parameter answers: Array of answers provided by the user
+    /// - Throws: An error if the submission fails
+    func submitSurveyAnswers(_ answers: [Answer]) throws {
+        for (index, answer) in answers.enumerated() {
+            try survey.submitAnswer(answer, forTaskId: currentTaskNumber, questionIndex: index)
+        }
+
+        advanceToNextTask()
+    }
+
+    /// Resets the study to its initial state
+    ///
+    /// This method clears all survey answers and resets the navigation state,
+    /// bringing the study back to its starting point.
+    func resetStudy() {
+        survey.resetAllAnswers()
+        currentTaskNumber = 0
+        isSurveyStarted = false
+        updateNavigationState()
+    }
+
+    /// Starts the survey portion of the study
+    ///
+    /// This method initializes the survey process if it hasn't already been started.
+    func startSurvey() {
+        if isSurveyStarted {
+            return
+        }
+        isSurveyStarted = true
+        currentTaskNumber = 1
+    }
+
+    /// Returns the current task if one is active
+    ///
+    /// - Returns: The current survey task, if available
+    func getCurrentTask() -> SurveyTask? {
+        survey.tasks.first { $0.id == currentTaskNumber }
+    }
+
+    private func generateReport() -> String {
+        survey.generateReport()
+    }
+
+    private func advanceToNextTask() {
+        if currentTaskNumber < survey.tasks.count {
+            currentTaskNumber += 1
+        } else {
+            navigationState = .completed
+        }
+    }
+
+    private func updateNavigationState() {
+        navigationState = currentTaskNumber == 0
+            ? .introduction
+            : currentTaskNumber <= survey.tasks.count
+                ? .task(number: currentTaskNumber, total: survey.tasks.count)
+                : .completed
+    }
+}

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatViewModel.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatViewModel.swift
@@ -17,7 +17,8 @@ import SwiftUI
 /// It provides UI-specific computed properties and methods while delegating
 /// LLM operations and persistence to the underlying interpreter.
 @MainActor
-final class UserStudyChatViewModel: ObservableObject {
+@Observable
+final class UserStudyChatViewModel {
     // MARK: - Navigation State
 
     /// The current state of the survey navigation
@@ -40,16 +41,16 @@ final class UserStudyChatViewModel: ObservableObject {
     }
 
     /// The current navigation state of the study
-    @Published private(set) var navigationState: NavigationState = .introduction
+    private(set) var navigationState: NavigationState = .introduction
 
     /// Indicates whether the survey portion has been started
-    @Published private(set) var isSurveyStarted = false
+    private(set) var isSurveyStarted = false
 
     /// Controls the visibility of the survey view
-    @Published var isSurveyViewPresented = false
+    var isSurveyViewPresented: Bool
 
     /// Controls the visibility of the dismiss confirmation dialog
-    @Published var isDismissDialogPresented = false
+    var isDismissDialogPresented: Bool
 
     private let survey: Survey
     private let interpreter: FHIRMultipleResourceInterpreter
@@ -125,6 +126,8 @@ final class UserStudyChatViewModel: ObservableObject {
     init(survey: Survey, interpreter: FHIRMultipleResourceInterpreter) {
         self.survey = survey
         self.interpreter = interpreter
+        self.isSurveyViewPresented = false
+        self.isDismissDialogPresented = false
     }
 
 

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatViewModel.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatViewModel.swift
@@ -60,15 +60,21 @@ final class UserStudyChatViewModel: ObservableObject {
         }
     }
 
+    /// Direct access to the current LLM session for observing state changes
+    var llmSession: LLMSession {
+        interpreter.llmSession
+    }
+
     /// Indicates if the LLM is currently processing or generating a response
     /// This property directly reflects the LLM session's state
     var isProcessing: Bool {
         llmSession.state.representation == .processing
     }
 
-    /// Direct access to the current LLM session for observing state changes
-    var llmSession: LLMSession {
-        interpreter.llmSession
+    /// Determines whether to display a typing indicator in the chat interface.
+    var showTypingIndicator: Bool {
+        let role = llmSession.context.last?.role
+        return role == .user || role == .system
     }
 
     /// Provides a binding to the chat messages for use in SwiftUI views
@@ -107,7 +113,6 @@ final class UserStudyChatViewModel: ObservableObject {
         // Check if there are no assistant messages yet (initial prompt needs a response)
         let noAssistantMessages = !interpreter.llmSession.context.contains(where: { $0.role == .assistant() })
 
-        // Generate if last message is from user or if there are no assistant messages yet
         return (lastMessageIsUser || noAssistantMessages)
     }
 

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatViewModel.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatViewModel.swift
@@ -131,14 +131,6 @@ final class UserStudyChatViewModel {
     }
 
 
-    /// Starts a new conversation by clearing all user and assistant messages
-    ///
-    /// This preserves system messages but removes all conversation history,
-    /// providing the user with a fresh chat while maintaining the interpreter context.
-    func startNewConversation() {
-        interpreter.startNewConversation()
-    }
-
     /// Generates an assistant response if appropriate for the current context
     ///
     /// This method checks if a response is needed and if so, delegates

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyWelcomeView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyWelcomeView.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct UserStudyWelcomeView: View {
     @Environment(LLMonFHIRStandard.self) private var standard
     @Environment(FHIRInterpretationModule.self) private var fhirInterpretationModule
+    @Environment(FHIRMultipleResourceInterpreter.self) private var interpreter
     @Environment(LLMOpenAITokenSaver.self) private var openAITokenSaver
     
     @State private var isPresentingSettings = false
@@ -36,7 +37,10 @@ struct UserStudyWelcomeView: View {
                 }
                 .fullScreenCover(isPresented: $isPresentingStudy) {
                     AccessGuarded(.userStudyIndentifier) {
-                        UserStudyChatView(survey: Survey(.defaultTasks))
+                        UserStudyChatView(
+                            survey: Survey(.defaultTasks),
+                            interpreter: interpreter
+                        )
                     }
                 }
                 .task {

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyWelcomeView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyWelcomeView.swift
@@ -110,7 +110,10 @@ struct UserStudyWelcomeView: View {
     }
 
     private var startStudyButton: some View {
-        Button(action: { isPresentingStudy = true }) {
+        Button {
+            interpreter.startNewConversation()
+            isPresentingStudy = true
+        } label: {
             Text("Start Session")
                 .font(.headline)
                 .fontWeight(.semibold)

--- a/LLMonFHIR/FHIRInterpretationModule.swift
+++ b/LLMonFHIR/FHIRInterpretationModule.swift
@@ -85,6 +85,6 @@ class FHIRInterpretationModule: Module, DefaultInitializable, EnvironmentAccessi
     func updateSchemas() {
         resourceSummary.changeLLMSchema(to: simpleOpenAISchema)
         resourceInterpreter.changeLLMSchema(to: simpleOpenAISchema)
-        multipleResourceInterpreter.changeLLMSchema(to: multipleResourceInterpreterOpenAISchema)
+        multipleResourceInterpreter.updateLLMSchema(to: multipleResourceInterpreterOpenAISchema)
     }
 }

--- a/LLMonFHIR/Home.swift
+++ b/LLMonFHIR/Home.swift
@@ -12,6 +12,7 @@ struct HomeView: View {
     @State private var showSettings = false
     @State private var showMultipleResourcesChat = false
     @AppStorage(StorageKeys.enableTextToSpeech) private var textToSpeech = StorageKeys.currentEnableTextToSpeech
+    @Environment(FHIRMultipleResourceInterpreter.self) var interpreter
 
 
     var body: some View {
@@ -25,6 +26,7 @@ struct HomeView: View {
                 }
                 .sheet(isPresented: $showMultipleResourcesChat) {
                     MultipleResourcesChatView(
+                        interpreter: interpreter,
                         navigationTitle: "LLM on FHIR",
                         textToSpeech: $textToSpeech
                     )

--- a/LLMonFHIR/Home.swift
+++ b/LLMonFHIR/Home.swift
@@ -11,7 +11,6 @@ import SwiftUI
 struct HomeView: View {
     @State private var showSettings = false
     @State private var showMultipleResourcesChat = false
-    @AppStorage(StorageKeys.enableTextToSpeech) private var textToSpeech = StorageKeys.currentEnableTextToSpeech
     @Environment(FHIRMultipleResourceInterpreter.self) var interpreter
 
 
@@ -27,8 +26,7 @@ struct HomeView: View {
                 .sheet(isPresented: $showMultipleResourcesChat) {
                     MultipleResourcesChatView(
                         interpreter: interpreter,
-                        navigationTitle: "LLM on FHIR",
-                        textToSpeech: $textToSpeech
+                        navigationTitle: "LLM on FHIR"
                     )
                 }
         }

--- a/LLMonFHIR/Settings/ResourceSelection.swift
+++ b/LLMonFHIR/Settings/ResourceSelection.swift
@@ -69,6 +69,9 @@ struct ResourceSelection: View {
                 showBundleSelection = !standard.useHealthKitResources || !HKHealthStore.isHealthDataAvailable()
                 self.bundles = await mockPatients
             }
+            .onDisappear {
+                fhirInterpretationModule.updateSchemas()
+            }
             .navigationTitle(Text("Resource Settings"))
     }
     
@@ -101,7 +104,5 @@ struct ResourceSelection: View {
                 await store.load(bundle: firstMockPatient)
             }
         }
-        
-        fhirInterpretationModule.updateSchemas()
     }
 }


### PR DESCRIPTION
# Refactor FHIR Multiple Resource Interpreter and Chat

## :recycle: Current situation & Problem
The current implementation has some architectural and performance limitations:

1. The views and the interpreter contain business logic that should be separated into a dedicated view model
2. ~~Every time `resetChat` was called, a new LLM session with a new context was created, causing the app to re-parse and re-interpret FHIR health data~~
3. The creation of new LLM sessions could trigger race conditions in `SpeziLLM`, potentially causing app crashes
5. No debug messages.

## :gear: Release Notes
* Refactored `MultipleResourcesChatView` and `UserStudyChatView` to use the MVVM pattern with a dedicated view model. The views interact only with their respected view models. 
* `llmState` is now properly encapsulated and only mutable within the interpreter context
* Extracted toolbar functionality into a new file.
* Modified the conversation reset to maintain system context and avoid expensive re-parsing of FHIR resources
* Added improved logic for determining when assistant responses should be generated with proper state handling
* Implemented cancellation of ongoing LLM operations to prevent any sort of of race conditions and leaks
* Added documentation throughout the components

### Some Implementation Details:
* ~~The implementation now properly uses `interpreter.startNewConversation()` which preserves system messages and only clears user and assistant messages.~~
* A full session reset will occur when the llm schema changes. See `FHIRMultipleResourceInterpreter.updateLLMSchema(to:)`
* Added `shouldGenerateResponse` property that checks multiple conditions before generating responses
* Ensured proper cancellation of LLM tasks with `interpreter.cancel()` when dismissing views

## :books: Documentation
Added in code

## :white_check_mark: Testing
Only manual testing


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
