### PR TITLE
Add the Post-Task Health Literacy to the app as Task 6

### DIFF
--- a/LLMonFHIR/FHIRInterpretation/UserStudy/Survey.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/Survey.swift
@@ -13,14 +13,14 @@ import Foundation
 
 /// Represents a user's response to a survey question
 enum Answer: Equatable {
-    case likertScale(Int)
+    case scale(Int)
     case freeText(String)
     case netPromoterScore(Int)
     case unanswered
 
     var rawValue: String {
         switch self {
-        case .likertScale(let value):
+        case .scale(let value):
             "\(value)"
         case .freeText(let value):
             "\(value)"
@@ -35,13 +35,13 @@ enum Answer: Equatable {
 
 /// Defines the type of question and its validation rules
 enum QuestionType {
-    case likertScale(responseOptions: [String])
+    case scale(responseOptions: [String])
     case freeText
     case netPromoterScore(range: ClosedRange<Int>)
 
     var range: ClosedRange<Int>? {
         switch self {
-        case .likertScale(let responseOptions):
+        case .scale(let responseOptions):
             return 1...(responseOptions.count)
         case .netPromoterScore(let range):
             return range
@@ -127,7 +127,7 @@ struct Question {
 
     private func validateAnswer(_ answer: Answer) throws {
         switch (type, answer) {
-        case let (.likertScale(responseOptions), .likertScale(value)):
+        case let (.scale(responseOptions), .scale(value)):
             guard let validRange = type.range else {
                 throw SurveyError.invalidRange(expected: 1...responseOptions.count)
             }

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/SurveyView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/SurveyView.swift
@@ -14,8 +14,8 @@ import SwiftUI
 /// Manages the state of answers for different types of survey questions
 @MainActor
 final class SurveyAnswerState: ObservableObject {
-    /// Stores answers for Likert scale questions, keyed by question index
-    @Published private(set) var likertScaleAnswers: [Int: Int] = [:]
+    /// Stores answers for scale questions, keyed by question index
+    @Published private(set) var scaleAnswers: [Int: Int] = [:]
 
     /// Stores answers for free text questions, keyed by question index
     @Published private(set) var freeTextAnswers: [Int: String] = [:]
@@ -29,8 +29,8 @@ final class SurveyAnswerState: ObservableObject {
     func getAnswers(for questions: [Question]) -> [Answer] {
         questions.enumerated().map { index, question in
             switch question.type {
-            case .likertScale:
-                return likertScaleAnswers[index].map { .likertScale($0) } ?? .unanswered
+            case .scale:
+                return scaleAnswers[index].map { .scale($0) } ?? .unanswered
             case .freeText:
                 return freeTextAnswers[index].map { .freeText($0) } ?? .unanswered
             case .netPromoterScore:
@@ -51,8 +51,8 @@ final class SurveyAnswerState: ObservableObject {
         }
 
         switch type {
-        case .likertScale:
-            return likertScaleAnswers[questionIndex] != nil
+        case .scale:
+            return scaleAnswers[questionIndex] != nil
         case .freeText:
             return freeTextAnswers[questionIndex]?.isEmpty == false
         case .netPromoterScore:
@@ -60,12 +60,12 @@ final class SurveyAnswerState: ObservableObject {
         }
     }
 
-    /// Updates the answer for a Likert scale question
+    /// Updates the answer for a scale question
     /// - Parameters:
     ///   - value: The selected value
     ///   - index: The question index
-    func updateLikertScale(value: Int, at index: Int) {
-        likertScaleAnswers[index] = value
+    func updateScale(value: Int, at index: Int) {
+        scaleAnswers[index] = value
     }
 
     /// Updates the answer for a free text question
@@ -112,8 +112,8 @@ struct QuestionSectionView: View {
 
     @ViewBuilder private var questionContent: some View {
         switch question.type {
-        case .likertScale(let responseOptions):
-            LikertScaleQuestionView(
+        case .scale(let responseOptions):
+            ScaleQuestionView(
                 index: index,
                 responseOptions: responseOptions,
                 answerState: answerState
@@ -176,8 +176,8 @@ struct RadioSelectionView: View {
 }
 
 
-/// A view for collecting Likert scale responses
-struct LikertScaleQuestionView: View {
+/// A view for collecting scale responses
+struct ScaleQuestionView: View {
     /// The index of this question
     let index: Int
 
@@ -195,7 +195,7 @@ struct LikertScaleQuestionView: View {
     var body: some View {
         RadioSelectionView(
             range: range,
-            selectedValue: answerState.likertScaleAnswers[index],
+            selectedValue: answerState.scaleAnswers[index],
             displayText: { value in
                 guard value > 0 && value <= responseOptions.count else {
                     return ""
@@ -203,7 +203,7 @@ struct LikertScaleQuestionView: View {
                 return responseOptions[value - 1]
             },
             onSelect: { value in
-                answerState.updateLikertScale(value: value, at: index)
+                answerState.updateScale(value: value, at: index)
             }
         )
     }

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyWelcomeView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyWelcomeView.swift
@@ -183,30 +183,45 @@ extension [SurveyTask] {
         "Much better"
     ]
 
+    private static let balancedEaseScale = [
+        "Very difficult",
+        "Somewhat difficult",
+        "Neither easy nor difficult",
+        "Somewhat easy",
+        "Very easy"
+    ]
+
+    private static let frequencyOptions = [
+        "Always",
+        "Often",
+        "Sometimes",
+        "Never"
+    ]
+
     /// Default set of survey tasks used in the user study
     static let defaultTasks: [SurveyTask] = [
         .init(id: 1, questions: [
             .init(
                 text: "How clear and understandable was the summary provided by the app?",
-                type: .likertScale(responseOptions: clarityScale)
+                type: .scale(responseOptions: clarityScale)
             )
         ]),
         .init(id: 2, questions: [
             .init(
                 text: "How effective is this feature for interpreting and evaluating your medical information?",
-                type: .likertScale(responseOptions: effectivenessScale)
+                type: .scale(responseOptions: effectivenessScale)
             )
         ]),
         .init(id: 3, questions: [
             .init(
                 text: "How effective are these recommendations in helping you make decisions about your health?",
-                type: .likertScale(responseOptions: effectivenessScale)
+                type: .scale(responseOptions: effectivenessScale)
             )
         ]),
         .init(id: 4, questions: [
             .init(
                 text: "How effective was the LLM in helping to answer your health question?",
-                type: .likertScale(responseOptions: effectivenessScale),
+                type: .scale(responseOptions: effectivenessScale),
                 isOptional: true
             ),
             .init(
@@ -218,7 +233,7 @@ extension [SurveyTask] {
         .init(id: 5, questions: [
             .init(
                 text: "Compared to other sources of health information (e.g., websites, doctors), how do you rate the LLM's responses?",
-                type: .likertScale(responseOptions: comparisonScale)
+                type: .scale(responseOptions: comparisonScale)
             ),
             .init(
                 text: "What were the most and least useful features of the LLM? Do you have any suggestions that you would like to share?",
@@ -233,6 +248,25 @@ extension [SurveyTask] {
             .init(
                 text: "On a scale of 0-10, how likely are you to recommend this tool to a friend or colleague?",
                 type: .netPromoterScore(range: 0...10)
+            )
+        ]),
+        .init(id: 6, questions: [
+            .init(
+                text: "How easy would it be to access or obtain information about your medical condition?",
+                type: .scale(responseOptions: balancedEaseScale)
+            ),
+            .init(
+                // swiftlint:disable:next line_length
+                text: "How frequently do you anticipate having problems learning about your medical condition because of difficulty understanding written information?",
+                type: .scale(responseOptions: frequencyOptions)
+            ),
+            .init(
+                text: "How confident would you be in filling out medical forms by yourself?",
+                type: .scale(responseOptions: frequencyOptions)
+            ),
+            .init(
+                text: "How often do you think you would have someone help you read hospital materials?",
+                type: .scale(responseOptions: frequencyOptions)
             )
         ])
     ]


### PR DESCRIPTION
# Add the Post-Task Health Literacy to the app as Task 6

## :gear: Release Notes
- Add the Post-Task Health Literacy to the app as Task 6. 
- Changed "Likert Scale" to "Scale" in the code to handle different Scale-related question types more easily.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
