### PR TITLE
Fix Token Removal

### DIFF
--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyWelcomeView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyWelcomeView.swift
@@ -46,7 +46,9 @@ struct UserStudyWelcomeView: View {
                     }
                 }
                 .task {
-                    openAITokenSaver.token = UserStudyPlistConfiguration.shared.apiKey ?? ""
+                    if openAITokenSaver.token.isEmpty {
+                        openAITokenSaver.token = UserStudyPlistConfiguration.shared.apiKey ?? ""
+                    }
                     await standard.loadHealthKitResources()
                     fhirInterpretationModule.updateSchemas()
                 }


### PR DESCRIPTION
# Fix Token Removal

## :recycle: Current situation & Problem
When switching between user study and non-user study modes, the app removes tokens because there is nothing stored in `UserStudyPlist`.

## :gear: Release Notes
The app now sets the API key from the plist when the token is empty.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
