### PR TITLE
Show the earliest health record date

### DIFF
--- a/LLMonFHIR/FHIRInterpretation/UserStudy/EarliestHealthRecordsView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/EarliestHealthRecordsView.swift
@@ -1,0 +1,52 @@
+//
+// This source file is part of the Stanford Spezi project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SwiftUI
+
+
+struct EarliestHealthRecordsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let dataSource: [String: Date]
+    let dateFormatter: DateFormatter
+
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section(footer: Text("\n\(Text("Records Since Disclaimer"))")) {
+                    ForEach(dataSource.keys.sorted(), id: \.self) { resourceType in
+                        if let date = dataSource[resourceType] {
+                            HStack {
+                                Text(resourceType)
+                                    .font(.headline)
+
+                                Spacer()
+
+                                Text(dateFormatter.string(from: date))
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Records since")
+            .navigationBarItems(trailing: doneButton)
+        }
+    }
+
+
+    private var doneButton: some View {
+        Button("Done") {
+            dismiss()
+        }
+    }
+}

--- a/LLMonFHIR/Resources/Localizable.xcstrings
+++ b/LLMonFHIR/Resources/Localizable.xcstrings
@@ -1,6 +1,9 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "\n%@" : {
+
+    },
     "%.2f" : {
 
     },
@@ -731,6 +734,9 @@
 
     },
     "Documents" : {
+
+    },
+    "Done" : {
 
     },
     "Download the LLM model to generate summaries of FHIR resources." : {
@@ -1572,6 +1578,20 @@
     },
     "Random" : {
 
+    },
+    "Records since" : {
+
+    },
+    "Records Since Disclaimer" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The dates shown represent the earliest records available for each category. However, not all records after these dates may be included, and only records with valid dates are shown. Due to technical limitations, some valid records may not appear. This timeline provides a general overview of when your health data begins, but is not a comprehensive index of all available records."
+          }
+        }
+      }
     },
     "Records since: %@" : {
 

--- a/LLMonFHIR/Resources/Localizable.xcstrings
+++ b/LLMonFHIR/Resources/Localizable.xcstrings
@@ -1573,6 +1573,9 @@
     "Random" : {
 
     },
+    "Records since: %@" : {
+
+    },
     "Reset Chat" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
# Show the earliest health record date

## :gear: Release Notes
- Display the earliest health record date available to the LLM on the user study’s welcome screen.
- When the date is tapped, go to the `EarliestHealthRecordsView`, which shows a detailed breakdown of the earliest date for each resource type the LLM can access.
- Include a disclaimer at the bottom of the `EarliestHealthRecordsView` explaining what the data represents.

| <img src="https://github.com/user-attachments/assets/8a6dc81d-4949-4c04-a884-05dbcf950772" width="250" alt="Simulator Screenshot - iPhone 16 Pro - 2025-04-11 at 17 39 30"> | <img src="https://github.com/user-attachments/assets/7d3f5ca0-3b95-4932-bbfe-8bee91d63f7a" width="250" alt="Simulator Screenshot - iPhone 16 Pro - 2025-04-11 at 17 39 48"> | <img src="https://github.com/user-attachments/assets/83bd7953-b384-4943-bcde-58c05c2974a2" width="250" alt="Simulator Screenshot - iPhone 16 Pro - 2025-04-11 at 17 39 51">
## :white_check_mark: Testing
Manually with various resource sizes.

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
