### PR TITLE
Resource Timeout

### DIFF
--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyWelcomeView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyWelcomeView.swift
@@ -145,6 +145,7 @@ struct UserStudyWelcomeView: View {
                 .fontWeight(.medium)
                 .underline()
         }
+        .opacity(standard.waitingState.isWaiting ? 0 : 1)
     }
 
     private var bottomSection: some View {
@@ -163,15 +164,23 @@ struct UserStudyWelcomeView: View {
             interpreter.startNewConversation()
             isPresentingStudy = true
         } label: {
-            Text("Start Session")
-                .font(.headline)
-                .fontWeight(.semibold)
-                .foregroundColor(.white)
-                .frame(maxWidth: .infinity)
-                .frame(height: 56)
-                .background(Color.accent)
-                .cornerRadius(16)
+            HStack(spacing: 8) {
+                if standard.waitingState.isWaiting {
+                    ProgressView()
+                        .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                }
+
+                Text(standard.waitingState.isWaiting ? "Loading Resources" : "Start Session")
+            }
+            .font(.headline)
+            .fontWeight(.semibold)
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 56)
+            .background(Color.accent.opacity(standard.waitingState.isWaiting ? 0.5 : 1))
+            .cornerRadius(16)
         }
+        .disabled(standard.waitingState.isWaiting)
     }
 
     private var approvalBadge: some View {

--- a/LLMonFHIR/LLMonFHIRStandard.swift
+++ b/LLMonFHIR/LLMonFHIRStandard.swift
@@ -13,37 +13,67 @@ import SpeziHealthKit
 import SwiftUI
 
 
+@MainActor
+@Observable
+class FHIRResourceWaitingState {
+    var isWaiting = true
+}
+
 actor LLMonFHIRStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
     @Dependency(FHIRStore.self) var fhirStore
     @Dependency(FHIRInterpretationModule.self) var fhirInterpretationModule
     
     @MainActor var useHealthKitResources = true
+
+    @MainActor let waitingState = FHIRResourceWaitingState()
+
     private var samples: [HKSample] = []
-    
-    
+    private var waitTask: Task<Void, Error>?
+
     func add(sample: HKSample) async {
         samples.append(sample)
         if await useHealthKitResources {
+            waitTask?.cancel()
+
             await fhirStore.add(sample: sample, loadHealthKitAttachements: true)
             await fhirInterpretationModule.updateSchemas()
+
+            waitTask = Task {
+                if !Task.isCancelled {
+                    await MainActor.run {
+                        waitingState.isWaiting = true
+                    }
+                    await waitForResourceInactivityTimeout(10.0)
+                }
+            }
         }
     }
-    
+
     func remove(sample: HKDeletedObject) async {
         samples.removeAll(where: { $0.id == sample.uuid })
         if await useHealthKitResources {
             await fhirStore.remove(sample: sample)
         }
     }
-    
+
     @MainActor
     func loadHealthKitResources() async {
         await fhirStore.removeAllResources()
-        
+
         for sample in await samples {
             await fhirStore.add(sample: sample)
         }
-        
+
         useHealthKitResources = true
+    }
+
+    private func waitForResourceInactivityTimeout(_ timeoutInterval: TimeInterval) async {
+        try? await Task.sleep(for: .seconds(timeoutInterval))
+
+        if !Task.isCancelled {
+            await MainActor.run {
+                waitingState.isWaiting = false
+            }
+        }
     }
 }

--- a/LLMonFHIR/ResourceView.swift
+++ b/LLMonFHIR/ResourceView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 
 struct ResourceView: View {
+    @Environment(LLMonFHIRStandard.self) private var standard
     @Environment(FHIRStore.self) private var fhirStore
     @Binding var showMultipleResourcesChat: Bool
     
@@ -28,12 +29,19 @@ struct ResourceView: View {
                     showMultipleResourcesChat.toggle()
                 },
                 label: {
-                    Text("CHAT_WITH_ALL_RESOURCES")
+                    HStack(spacing: 8) {
+                        if standard.waitingState.isWaiting {
+                            ProgressView()
+                                .progressViewStyle(.circular)
+                        }
+                        Text(standard.waitingState.isWaiting ? "Loading Resources" : "Chat with all Resources")
+                    }
                         .frame(maxWidth: .infinity, minHeight: 38)
                 }
             )
-            .buttonStyle(.borderedProminent)
-            .padding(-20)
+                .buttonStyle(.borderedProminent)
+                .padding(-20)
+                .disabled(standard.waitingState.isWaiting)
         }
         .task {
             if FeatureFlags.testMode {

--- a/LLMonFHIR/Resources/Localizable.xcstrings
+++ b/LLMonFHIR/Resources/Localizable.xcstrings
@@ -25,7 +25,11 @@
     "Cancel" : {
 
     },
+    "Chat with all Resources" : {
+
+    },
     "CHAT_WITH_ALL_RESOURCES" : {
+      "extractionState" : "stale",
       "localizations" : {
         "de" : {
           "stringUnit" : {

--- a/LLMonFHIR/Resources/Localizable.xcstrings
+++ b/LLMonFHIR/Resources/Localizable.xcstrings
@@ -1344,6 +1344,9 @@
         }
       }
     },
+    "Loading Resources" : {
+
+    },
     "Medications" : {
       "localizations" : {
         "de" : {


### PR DESCRIPTION
# Resource Timeout

## :recycle: Current situation & Problem
Because resources are added in the background, we risk starting the user study before all resources are fully loaded, especially with large health resources. This could cause glitches and make the chat unusable until all resources are completely added.

## :gear: Release Notes
I added a simple timeout mechanism that waits for all resources to load. It assumes the process is complete if no new resources are added for 10 seconds.

**Note:** There's still no guarantee all resources will be loaded when the user study starts, but this mechanism reduces the likelihood of this issue.

## :books: Documentation
N/A


## :white_check_mark: Testing
Tested manually. 


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
