### PR TITLE
Add visual indicator for next button action

### DIFF
--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatToolbar.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatToolbar.swift
@@ -9,6 +9,45 @@
 import SwiftUI
 
 
+private struct PulsatingEffect: ViewModifier {
+    let isEnabled: Bool
+    @State private var scale: CGFloat = 1.0
+
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(scale)
+            .onChange(of: isEnabled) { _, newValue in
+                if newValue {
+                    startPulsing()
+                } else {
+                    stopPulsing()
+                }
+            }
+            .onAppear {
+                if isEnabled {
+                    startPulsing()
+                }
+            }
+    }
+
+
+    private func startPulsing() {
+        withAnimation(
+            .easeInOut(duration: 1.0)
+            .repeatForever(autoreverses: true)
+        ) {
+            scale = 1.2
+        }
+    }
+
+    private func stopPulsing() {
+        withAnimation {
+            scale = 1.0
+        }
+    }
+}
+
 struct UserStudyChatToolbar: ToolbarContent {
     @State private(set) var viewModel: UserStudyChatViewModel
 
@@ -57,6 +96,7 @@ struct UserStudyChatToolbar: ToolbarContent {
                 } label: {
                     Image(systemName: "arrow.forward.circle")
                         .accessibilityLabel("Next Task")
+                        .modifier(PulsatingEffect(isEnabled: !isInputDisabled))
                 }
                 .disabled(isInputDisabled)
             }


### PR DESCRIPTION
# Add visual indicator for next button action

#101 

## :recycle: Current situation & Problem
Once the necessary messages are exchanged, users are confused about which button to press next during a user sturdy.


## :gear: Release Notes
Add a pulsating effect (scaling to 1.2 and back) to the button that should be pressed next. This effect should only start after the required number of messages has been completed.

https://github.com/user-attachments/assets/7dd84dda-adbd-4388-88a4-d2d859505fcc


## :books: Documentation
N/A


## :white_check_mark: Testing
N/A


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
