### PR TITLE
Fix app hang when importing empty Apple Health data

### DIFF
--- a/LLMonFHIR/LLMonFHIRStandard.swift
+++ b/LLMonFHIR/LLMonFHIRStandard.swift
@@ -69,5 +69,9 @@ actor LLMonFHIRStandard: Standard, HealthKitConstraint, EnvironmentAccessible {
         }
 
         useHealthKitResources = true
+
+        if await fhirStore.allResources.isEmpty {
+            waitingState.isWaiting = false
+        }
     }
 }

--- a/LLMonFHIR/ResourceView.swift
+++ b/LLMonFHIR/ResourceView.swift
@@ -47,6 +47,10 @@ struct ResourceView: View {
             if FeatureFlags.testMode {
                 await fhirStore.loadTestingResources()
             }
+
+            if fhirStore.allResources.isEmpty {
+                standard.waitingState.isWaiting = false
+            }
         }
     }
 }


### PR DESCRIPTION
# Fix app hang when importing empty Apple Health data

Resolving #104 

## :recycle: Current situation & Problem
This bug happens when Apple Health has no health records. When the app gets health records, it waits up to 10 seconds between each new record. If no new records appear for 10 seconds, the app assumes all records have been added and stops waiting.

## :gear: Release Notes
Set `isWaiting` to false when there are no health records. 


## :books: Documentation
N/A

## :white_check_mark: Testing
Manually tested

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
