### PR TITLE
Add progress tracking with status updates

### DIFF
--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatView.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatView.swift
@@ -16,7 +16,7 @@ struct UserStudyChatView: View {
 
     var body: some View {
         NavigationStack { // swiftlint:disable:this closure_body_length
-            chatContent
+            chatView
                 .navigationTitle(viewModel.navigationState.title)
                 .navigationBarTitleDisplayMode(.inline)
                 .toolbar {
@@ -56,6 +56,9 @@ struct UserStudyChatView: View {
                 .onAppear(perform: viewModel.startSurvey)
                 .onChange(of: viewModel.llmSession.context, initial: true) {
                     Task {
+                        if viewModel.isProcessing {
+                            viewModel.updateProcessingState()
+                        }
                         _ = await viewModel.generateAssistantResponse()
                     }
                 }
@@ -63,16 +66,33 @@ struct UserStudyChatView: View {
     }
 
 
-    @ViewBuilder private var chatContent: some View {
-        ChatView(
-            viewModel.chatBinding,
-            disableInput: viewModel.shouldDisableChatInput,
-            speechToText: false,
-            messagePendingAnimation: .manual(shouldDisplay: viewModel.showTypingIndicator)
-        )
-            .viewStateAlert(state: viewModel.llmSession.state)
-    }
+    @ViewBuilder private var chatView: some View {
+        VStack {
+            if viewModel.isProcessing {
+                VStack(spacing: 8) {
+                    ProgressView(value: viewModel.processingState.progress, total: 100)
+                        .progressViewStyle(.linear)
+                        .tint(.accentColor)
 
+                    Text(viewModel.processingState.statusDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+                .background(.ultraThinMaterial)
+                .padding(.bottom, 8)
+            }
+
+            ChatView(
+                viewModel.chatBinding,
+                disableInput: viewModel.shouldDisableChatInput,
+                speechToText: false,
+                messagePendingAnimation: .manual(shouldDisplay: viewModel.showTypingIndicator)
+            )
+            .viewStateAlert(state: viewModel.llmSession.state)
+        }
+    }
 
     /// Creates a new user study chat view
     ///

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyViewModel+ProcessingState.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyViewModel+ProcessingState.swift
@@ -1,0 +1,45 @@
+//
+// This source file is part of the Stanford Spezi project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension UserStudyChatViewModel {
+    enum ProcessingState: Equatable {
+        case processingSystemPrompts
+        case processingFunctionCalls(progress: Double, currentCall: Int, totalCalls: Int)
+        case generatingResponse
+        case completed
+
+        var progress: Double {
+            switch self {
+            case .processingSystemPrompts:
+                return 0
+            case .processingFunctionCalls(let progress, _, _):
+                return 20 + progress * 70
+            case .generatingResponse:
+                return 90
+            case .completed:
+                return 100
+            }
+        }
+
+        var statusDescription: String {
+            switch self {
+            case .processingSystemPrompts:
+                return "Processing system prompts..."
+            case let .processingFunctionCalls(_, current, total):
+                return "Processing function calls (\(current)/\(total))..."
+            case .generatingResponse:
+                return "Generating response..."
+            case .completed:
+                return "Processing completed"
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Add progress tracking with status updates

#103

## :recycle: Current situation & Problem
A few things happen behind the scenes before the user sees a generated message. The system processes prompts and makes multiple function calls.
This can take a while, especially for users with lots of health data. If we only show a typing indicator or loading spinner, users might think the app is broken or stuck.
That's why we should show a progress bar with status updates for each message being generated.


## :gear: Release Notes
Adds a progress bar below the navigation bar to show the model's status as it processes system prompts, makes function calls, and generates a response.

https://github.com/user-attachments/assets/7ce263d3-6329-4e70-9152-fdf62d5c257c

## :books: Documentation
N/A

## :white_check_mark: Testing
Manually tested

### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
