### PR TITLE
Show loading indicator during tool call

### DIFF
--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatViewModel.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyChatViewModel.swift
@@ -79,8 +79,7 @@ final class UserStudyChatViewModel {  // swiftlint:disable:this type_body_length
 
     /// Determines whether to display a typing indicator in the chat interface.
     var showTypingIndicator: Bool {
-        let role = llmSession.context.last?.role
-        return role == .user || role == .system
+        processingState.isProcessing
     }
 
     var shouldDisableChatInput: Bool {

--- a/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyViewModel+ProcessingState.swift
+++ b/LLMonFHIR/FHIRInterpretation/UserStudy/UserStudyViewModel+ProcessingState.swift
@@ -42,5 +42,14 @@ extension UserStudyChatViewModel {
                 return "Processing completed"
             }
         }
+
+        var isProcessing: Bool {
+            switch self {
+            case .processingSystemPrompts, .processingFunctionCalls:
+                return true
+            case .generatingResponse, .completed:
+                return false
+            }
+        }
     }
 }


### PR DESCRIPTION
# Show loading indicator during tool call

#99 

## :recycle: Current situation & Problem
Loading indicator was not shown when the model was executing the functions calls. 


## :gear: Release Notes
Loading indicator is displayed when the model is interpreting the user, system prompts and when it's executing all the function calls.

https://github.com/user-attachments/assets/622e2a0d-0082-484a-bb9a-5441020dd57d

## :books: Documentation
N/A


## :white_check_mark: Testing
Manually tested


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
