### PR TITLE
improve the decrypt tool

### DIFF
--- a/tools/decrypt-study-report/main.py
+++ b/tools/decrypt-study-report/main.py
@@ -16,7 +16,7 @@ import sys
 import base64
 import typing
 
-def decrypt(key: x25519.X25519PrivateKey, input: bytes):
+def decrypt(key: x25519.X25519PrivateKey, input: bytes) -> bytes:
     ephemeral_public_key_data = input[:32]
     ciphertext = input[32:]
     ephemeral_public_key = x25519.X25519PublicKey.from_public_bytes(ephemeral_public_key_data)
@@ -25,20 +25,26 @@ def decrypt(key: x25519.X25519PrivateKey, input: bytes):
     symmetric_key = kdf.derive(shared_secret)
     aesgcm = AESGCM(symmetric_key)
     plaintext = aesgcm.decrypt(ciphertext[:12], ciphertext[12:], None)
-    print(plaintext)
+    return plaintext
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         prog='DecryptLLMonFHIRStudyReport',
         description='Decrypts encrypted study reports from the LLMonFHIR app'
     )
-    parser.add_argument('filename', type=Path)
-    parser.add_argument('-k', '--key', type=Path, required=True)
+    parser.add_argument('-k', '--key', type=Path, required=True, help='the private key for decrypting the file')
+    parser.add_argument('-i', '--in-place', action='store_true',
+                        help='whether the output should be written to the input file, replacing the previous (encrypted) contents. ignored if the input is piped in via STDIN')
+    parser.add_argument('file', type=Path, help='the file to decrypt')
     args = parser.parse_args()
     key_bytes: bytes = typing.cast(Path, args.key).read_bytes().split(b'\n')[1]
     key_bytes = base64.decodebytes(key_bytes)[-32:]
     key = x25519.X25519PrivateKey.from_private_bytes(key_bytes)
-    filename: Path = args.filename
-    input: bytes = bytes(sys.stdin.read(), 'utf8') if filename == Path('-') else filename.read_bytes()
-    input = base64.decodebytes(input)
-    decrypt(key, input)
+    file: Path = args.file
+    input_is_stdin = file == Path('-')
+    input: bytes = sys.stdin.buffer.read() if input_is_stdin else file.read_bytes()
+    output = decrypt(key, input)
+    if not input_is_stdin and args.in_place:
+        file.write_bytes(output)
+    else:
+        print(output.decode())


### PR DESCRIPTION
# improve the decrypt tool

## :recycle: Current situation & Problem
the decrypt tool currently doesn't always quite work as expected.


## :gear: Release Notes
- decrypt tool:
    - no longer assumes the input is base64-encoded
    - fixed a bug where piping in the input via STDIN would sometimes fail
    - added an option to overwrite the input file in-place (disabled by default)


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
